### PR TITLE
Chore/link backend to executor

### DIFF
--- a/backend/env/.env.development
+++ b/backend/env/.env.development
@@ -1,2 +1,4 @@
 NODE_ENV=development
 PORT=8000
+EXECUTOR_REGION=us-east-1
+EXECUTOR_NAME=executor-dev

--- a/backend/env/.env.development
+++ b/backend/env/.env.development
@@ -1,4 +1,4 @@
 NODE_ENV=development
 PORT=8000
-EXECUTOR_REGION=us-east-1
+EXECUTOR_REGION=ap-southeast-1
 EXECUTOR_NAME=executor-dev

--- a/backend/env/.env.local
+++ b/backend/env/.env.local
@@ -1,2 +1,4 @@
 NODE_ENV=local
 PORT=8000
+EXECUTOR_REGION=us-east-1
+EXECUTOR_NAME=executor-dev

--- a/backend/env/.env.local
+++ b/backend/env/.env.local
@@ -1,4 +1,4 @@
 NODE_ENV=local
 PORT=8000
-EXECUTOR_REGION=us-east-1
+EXECUTOR_REGION=ap-southeast-1
 EXECUTOR_NAME=executor-dev

--- a/backend/env/.env.production
+++ b/backend/env/.env.production
@@ -1,4 +1,4 @@
 NODE_ENV=production
 PORT=8000
-EXECUTOR_REGION=us-east-1
+EXECUTOR_REGION=ap-southeast-1
 EXECUTOR_NAME=executor-prod

--- a/backend/env/.env.production
+++ b/backend/env/.env.production
@@ -1,2 +1,4 @@
 NODE_ENV=production
 PORT=8000
+EXECUTOR_REGION=us-east-1
+EXECUTOR_NAME=executor-prod

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -18,8 +18,8 @@
 				"joi": "^17.9.2",
 				"pino": "^8.14.1",
 				"pino-http": "^8.3.3",
-				"swagger-jsdoc": "^6.2.8",
-				"swagger-ui-express": "^4.6.3"
+				"swagger-ui-express": "^4.6.3",
+				"yaml": "^2.3.0"
 			},
 			"devDependencies": {
 				"@types/convict": "^6.1.1",
@@ -53,46 +53,6 @@
 			},
 			"engines": {
 				"node": ">=6.0.0"
-			}
-		},
-		"node_modules/@apidevtools/json-schema-ref-parser": {
-			"version": "9.1.2",
-			"resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.1.2.tgz",
-			"integrity": "sha512-r1w81DpR+KyRWd3f+rk6TNqMgedmAxZP5v5KWlXQWlgMUUtyEJch0DKEci1SorPMiSeM8XPl7MZ3miJ60JIpQg==",
-			"dependencies": {
-				"@jsdevtools/ono": "^7.1.3",
-				"@types/json-schema": "^7.0.6",
-				"call-me-maybe": "^1.0.1",
-				"js-yaml": "^4.1.0"
-			}
-		},
-		"node_modules/@apidevtools/openapi-schemas": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/@apidevtools/openapi-schemas/-/openapi-schemas-2.1.0.tgz",
-			"integrity": "sha512-Zc1AlqrJlX3SlpupFGpiLi2EbteyP7fXmUOGup6/DnkRgjP9bgMM/ag+n91rsv0U1Gpz0H3VILA/o3bW7Ua6BQ==",
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/@apidevtools/swagger-methods": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/@apidevtools/swagger-methods/-/swagger-methods-3.0.2.tgz",
-			"integrity": "sha512-QAkD5kK2b1WfjDS/UQn/qQkbwF31uqRjPTrsCs5ZG9BQGAkjwvqGFjjPqAuzac/IYzpPtRzjCP1WrTuAIjMrXg=="
-		},
-		"node_modules/@apidevtools/swagger-parser": {
-			"version": "10.0.3",
-			"resolved": "https://registry.npmjs.org/@apidevtools/swagger-parser/-/swagger-parser-10.0.3.tgz",
-			"integrity": "sha512-sNiLY51vZOmSPFZA5TF35KZ2HbgYklQnTSDnkghamzLb3EkNtcQnrBQEj5AOCxHpTtXpqMCRM1CrmV2rG6nw4g==",
-			"dependencies": {
-				"@apidevtools/json-schema-ref-parser": "^9.0.6",
-				"@apidevtools/openapi-schemas": "^2.0.4",
-				"@apidevtools/swagger-methods": "^3.0.2",
-				"@jsdevtools/ono": "^7.1.3",
-				"call-me-maybe": "^1.0.1",
-				"z-schema": "^5.0.1"
-			},
-			"peerDependencies": {
-				"openapi-types": ">=7"
 			}
 		},
 		"node_modules/@aws-crypto/crc32": {
@@ -2684,11 +2644,6 @@
 				"@jridgewell/sourcemap-codec": "^1.4.10"
 			}
 		},
-		"node_modules/@jsdevtools/ono": {
-			"version": "7.1.3",
-			"resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
-			"integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg=="
-		},
 		"node_modules/@kwsites/file-exists": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/@kwsites/file-exists/-/file-exists-1.1.1.tgz",
@@ -3244,7 +3199,8 @@
 		"node_modules/@types/json-schema": {
 			"version": "7.0.11",
 			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
-			"integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ=="
+			"integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
+			"dev": true
 		},
 		"node_modules/@types/keyv": {
 			"version": "3.1.4",
@@ -3909,7 +3865,8 @@
 		"node_modules/argparse": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+			"dev": true
 		},
 		"node_modules/array-flatten": {
 			"version": "1.1.1",
@@ -4141,7 +4098,8 @@
 		"node_modules/balanced-match": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+			"dev": true
 		},
 		"node_modules/base64-js": {
 			"version": "1.5.1",
@@ -4271,6 +4229,7 @@
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"dev": true,
 			"dependencies": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
@@ -4485,11 +4444,6 @@
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
-		},
-		"node_modules/call-me-maybe": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.2.tgz",
-			"integrity": "sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ=="
 		},
 		"node_modules/callsites": {
 			"version": "3.1.0",
@@ -4932,14 +4886,6 @@
 				"node": ">= 0.8"
 			}
 		},
-		"node_modules/commander": {
-			"version": "6.2.0",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-6.2.0.tgz",
-			"integrity": "sha512-zP4jEKbe8SHzKJYQmq8Y9gYjtO/POJLgIdKgV7B9qNmABVFVc+ctqSX6iXh4mCpJfRBOabiZ2YKPg8ciDw6C+Q==",
-			"engines": {
-				"node": ">= 6"
-			}
-		},
 		"node_modules/component-emitter": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
@@ -4978,7 +4924,8 @@
 		"node_modules/concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
+			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+			"dev": true
 		},
 		"node_modules/content-disposition": {
 			"version": "0.5.4",
@@ -5552,6 +5499,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
 			"integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+			"dev": true,
 			"dependencies": {
 				"esutils": "^2.0.2"
 			},
@@ -5903,6 +5851,7 @@
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
 			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -6553,7 +6502,8 @@
 		"node_modules/fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-			"integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
+			"integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+			"dev": true
 		},
 		"node_modules/fs2": {
 			"version": "0.3.9",
@@ -7072,6 +7022,7 @@
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+			"dev": true,
 			"dependencies": {
 				"once": "^1.3.0",
 				"wrappy": "1"
@@ -8050,6 +8001,7 @@
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
 			"integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+			"dev": true,
 			"dependencies": {
 				"argparse": "^2.0.1"
 			},
@@ -8451,12 +8403,8 @@
 		"node_modules/lodash.get": {
 			"version": "4.4.2",
 			"resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-			"integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ=="
-		},
-		"node_modules/lodash.isequal": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-			"integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ=="
+			"integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
+			"dev": true
 		},
 		"node_modules/lodash.isplainobject": {
 			"version": "4.0.6",
@@ -8475,11 +8423,6 @@
 			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
 			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
 			"dev": true
-		},
-		"node_modules/lodash.mergewith": {
-			"version": "4.6.2",
-			"resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
-			"integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ=="
 		},
 		"node_modules/lodash.union": {
 			"version": "4.6.0",
@@ -8741,6 +8684,7 @@
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
 			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+			"dev": true,
 			"dependencies": {
 				"brace-expansion": "^1.1.7"
 			},
@@ -9092,6 +9036,7 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+			"dev": true,
 			"dependencies": {
 				"wrappy": "1"
 			}
@@ -9127,12 +9072,6 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
-		},
-		"node_modules/openapi-types": {
-			"version": "12.1.0",
-			"resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.1.0.tgz",
-			"integrity": "sha512-XpeCy01X6L5EpP+6Hc3jWN7rMZJ+/k1lwki/kTmWzbVhdPie3jd5O2ZtedEx8Yp58icJ0osVldLMrTB/zslQXA==",
-			"peer": true
 		},
 		"node_modules/optionator": {
 			"version": "0.9.1",
@@ -9324,6 +9263,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
 			"integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -10888,55 +10828,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/swagger-jsdoc": {
-			"version": "6.2.8",
-			"resolved": "https://registry.npmjs.org/swagger-jsdoc/-/swagger-jsdoc-6.2.8.tgz",
-			"integrity": "sha512-VPvil1+JRpmJ55CgAtn8DIcpBs0bL5L3q5bVQvF4tAW/k/9JYSj7dCpaYCAv5rufe0vcCbBRQXGvzpkWjvLklQ==",
-			"dependencies": {
-				"commander": "6.2.0",
-				"doctrine": "3.0.0",
-				"glob": "7.1.6",
-				"lodash.mergewith": "^4.6.2",
-				"swagger-parser": "^10.0.3",
-				"yaml": "2.0.0-1"
-			},
-			"bin": {
-				"swagger-jsdoc": "bin/swagger-jsdoc.js"
-			},
-			"engines": {
-				"node": ">=12.0.0"
-			}
-		},
-		"node_modules/swagger-jsdoc/node_modules/glob": {
-			"version": "7.1.6",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-			"integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
-			"dependencies": {
-				"fs.realpath": "^1.0.0",
-				"inflight": "^1.0.4",
-				"inherits": "2",
-				"minimatch": "^3.0.4",
-				"once": "^1.3.0",
-				"path-is-absolute": "^1.0.0"
-			},
-			"engines": {
-				"node": "*"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/swagger-parser": {
-			"version": "10.0.3",
-			"resolved": "https://registry.npmjs.org/swagger-parser/-/swagger-parser-10.0.3.tgz",
-			"integrity": "sha512-nF7oMeL4KypldrQhac8RyHerJeGPD1p2xDh900GPvc+Nk7nWP6jX2FcC7WmkinMoAmoO774+AFXcWsW8gMWEIg==",
-			"dependencies": {
-				"@apidevtools/swagger-parser": "10.0.3"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
 		"node_modules/swagger-ui-dist": {
 			"version": "4.18.3",
 			"resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-4.18.3.tgz",
@@ -11586,14 +11477,6 @@
 				"builtins": "^1.0.3"
 			}
 		},
-		"node_modules/validator": {
-			"version": "13.9.0",
-			"resolved": "https://registry.npmjs.org/validator/-/validator-13.9.0.tgz",
-			"integrity": "sha512-B+dGG8U3fdtM0/aNK4/X8CXq/EcxU2WPrPEkJGslb47qyHsxmbggTWK0yEA4qnYVNF+nxNlN88o14hIcPmSIEA==",
-			"engines": {
-				"node": ">= 0.10"
-			}
-		},
 		"node_modules/vary": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -11700,7 +11583,8 @@
 		"node_modules/wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+			"dev": true
 		},
 		"node_modules/write-file-atomic": {
 			"version": "4.0.2",
@@ -11783,11 +11667,12 @@
 			"dev": true
 		},
 		"node_modules/yaml": {
-			"version": "2.0.0-1",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.0.0-1.tgz",
-			"integrity": "sha512-W7h5dEhywMKenDJh2iX/LABkbFnBxasD27oyXWDS/feDsxiw0dD5ncXdYXgkvAsXIY2MpW/ZKkr9IU30DBdMNQ==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.0.tgz",
+			"integrity": "sha512-8/1wgzdKc7bc9E6my5wZjmdavHLvO/QOmLG1FBugblEvY4IXrLjlViIOmL24HthU042lWTDRO90Fz1Yp66UnMw==",
 			"engines": {
-				"node": ">= 6"
+				"node": ">= 14",
+				"npm": ">= 7"
 			}
 		},
 		"node_modules/yaml-ast-parser": {
@@ -11885,34 +11770,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/z-schema": {
-			"version": "5.0.5",
-			"resolved": "https://registry.npmjs.org/z-schema/-/z-schema-5.0.5.tgz",
-			"integrity": "sha512-D7eujBWkLa3p2sIpJA0d1pr7es+a7m0vFAnZLlCEKq/Ij2k0MLi9Br2UPxoxdYystm5K1yeBGzub0FlYUEWj2Q==",
-			"dependencies": {
-				"lodash.get": "^4.4.2",
-				"lodash.isequal": "^4.5.0",
-				"validator": "^13.7.0"
-			},
-			"bin": {
-				"z-schema": "bin/z-schema"
-			},
-			"engines": {
-				"node": ">=8.0.0"
-			},
-			"optionalDependencies": {
-				"commander": "^9.4.1"
-			}
-		},
-		"node_modules/z-schema/node_modules/commander": {
-			"version": "9.5.0",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
-			"integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
-			"optional": true,
-			"engines": {
-				"node": "^12.20.0 || >=14"
-			}
-		},
 		"node_modules/zip-stream": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-4.1.0.tgz",
@@ -11951,40 +11808,6 @@
 			"requires": {
 				"@jridgewell/gen-mapping": "^0.3.0",
 				"@jridgewell/trace-mapping": "^0.3.9"
-			}
-		},
-		"@apidevtools/json-schema-ref-parser": {
-			"version": "9.1.2",
-			"resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.1.2.tgz",
-			"integrity": "sha512-r1w81DpR+KyRWd3f+rk6TNqMgedmAxZP5v5KWlXQWlgMUUtyEJch0DKEci1SorPMiSeM8XPl7MZ3miJ60JIpQg==",
-			"requires": {
-				"@jsdevtools/ono": "^7.1.3",
-				"@types/json-schema": "^7.0.6",
-				"call-me-maybe": "^1.0.1",
-				"js-yaml": "^4.1.0"
-			}
-		},
-		"@apidevtools/openapi-schemas": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/@apidevtools/openapi-schemas/-/openapi-schemas-2.1.0.tgz",
-			"integrity": "sha512-Zc1AlqrJlX3SlpupFGpiLi2EbteyP7fXmUOGup6/DnkRgjP9bgMM/ag+n91rsv0U1Gpz0H3VILA/o3bW7Ua6BQ=="
-		},
-		"@apidevtools/swagger-methods": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/@apidevtools/swagger-methods/-/swagger-methods-3.0.2.tgz",
-			"integrity": "sha512-QAkD5kK2b1WfjDS/UQn/qQkbwF31uqRjPTrsCs5ZG9BQGAkjwvqGFjjPqAuzac/IYzpPtRzjCP1WrTuAIjMrXg=="
-		},
-		"@apidevtools/swagger-parser": {
-			"version": "10.0.3",
-			"resolved": "https://registry.npmjs.org/@apidevtools/swagger-parser/-/swagger-parser-10.0.3.tgz",
-			"integrity": "sha512-sNiLY51vZOmSPFZA5TF35KZ2HbgYklQnTSDnkghamzLb3EkNtcQnrBQEj5AOCxHpTtXpqMCRM1CrmV2rG6nw4g==",
-			"requires": {
-				"@apidevtools/json-schema-ref-parser": "^9.0.6",
-				"@apidevtools/openapi-schemas": "^2.0.4",
-				"@apidevtools/swagger-methods": "^3.0.2",
-				"@jsdevtools/ono": "^7.1.3",
-				"call-me-maybe": "^1.0.1",
-				"z-schema": "^5.0.1"
 			}
 		},
 		"@aws-crypto/crc32": {
@@ -14250,11 +14073,6 @@
 				"@jridgewell/sourcemap-codec": "^1.4.10"
 			}
 		},
-		"@jsdevtools/ono": {
-			"version": "7.1.3",
-			"resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
-			"integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg=="
-		},
 		"@kwsites/file-exists": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/@kwsites/file-exists/-/file-exists-1.1.1.tgz",
@@ -14763,7 +14581,8 @@
 		"@types/json-schema": {
 			"version": "7.0.11",
 			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
-			"integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ=="
+			"integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
+			"dev": true
 		},
 		"@types/keyv": {
 			"version": "3.1.4",
@@ -15264,7 +15083,8 @@
 		"argparse": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+			"dev": true
 		},
 		"array-flatten": {
 			"version": "1.1.1",
@@ -15449,7 +15269,8 @@
 		"balanced-match": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+			"dev": true
 		},
 		"base64-js": {
 			"version": "1.5.1",
@@ -15545,6 +15366,7 @@
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"dev": true,
 			"requires": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
@@ -15695,11 +15517,6 @@
 				"function-bind": "^1.1.1",
 				"get-intrinsic": "^1.0.2"
 			}
-		},
-		"call-me-maybe": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.2.tgz",
-			"integrity": "sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ=="
 		},
 		"callsites": {
 			"version": "3.1.0",
@@ -16026,11 +15843,6 @@
 				"delayed-stream": "~1.0.0"
 			}
 		},
-		"commander": {
-			"version": "6.2.0",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-6.2.0.tgz",
-			"integrity": "sha512-zP4jEKbe8SHzKJYQmq8Y9gYjtO/POJLgIdKgV7B9qNmABVFVc+ctqSX6iXh4mCpJfRBOabiZ2YKPg8ciDw6C+Q=="
-		},
 		"component-emitter": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
@@ -16065,7 +15877,8 @@
 		"concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
+			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+			"dev": true
 		},
 		"content-disposition": {
 			"version": "0.5.4",
@@ -16525,6 +16338,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
 			"integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+			"dev": true,
 			"requires": {
 				"esutils": "^2.0.2"
 			}
@@ -16798,7 +16612,8 @@
 		"esutils": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
+			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+			"dev": true
 		},
 		"etag": {
 			"version": "1.8.1",
@@ -17311,7 +17126,8 @@
 		"fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-			"integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
+			"integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+			"dev": true
 		},
 		"fs2": {
 			"version": "0.3.9",
@@ -17679,6 +17495,7 @@
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+			"dev": true,
 			"requires": {
 				"once": "^1.3.0",
 				"wrappy": "1"
@@ -18416,6 +18233,7 @@
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
 			"integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+			"dev": true,
 			"requires": {
 				"argparse": "^2.0.1"
 			}
@@ -18760,12 +18578,8 @@
 		"lodash.get": {
 			"version": "4.4.2",
 			"resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-			"integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ=="
-		},
-		"lodash.isequal": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-			"integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ=="
+			"integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
+			"dev": true
 		},
 		"lodash.isplainobject": {
 			"version": "4.0.6",
@@ -18784,11 +18598,6 @@
 			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
 			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
 			"dev": true
-		},
-		"lodash.mergewith": {
-			"version": "4.6.2",
-			"resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
-			"integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ=="
 		},
 		"lodash.union": {
 			"version": "4.6.0",
@@ -18991,6 +18800,7 @@
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
 			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+			"dev": true,
 			"requires": {
 				"brace-expansion": "^1.1.7"
 			}
@@ -19256,6 +19066,7 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+			"dev": true,
 			"requires": {
 				"wrappy": "1"
 			}
@@ -19279,12 +19090,6 @@
 				"is-docker": "^2.1.1",
 				"is-wsl": "^2.2.0"
 			}
-		},
-		"openapi-types": {
-			"version": "12.1.0",
-			"resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.1.0.tgz",
-			"integrity": "sha512-XpeCy01X6L5EpP+6Hc3jWN7rMZJ+/k1lwki/kTmWzbVhdPie3jd5O2ZtedEx8Yp58icJ0osVldLMrTB/zslQXA==",
-			"peer": true
 		},
 		"optionator": {
 			"version": "0.9.1",
@@ -19418,7 +19223,8 @@
 		"path-is-absolute": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-			"integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg=="
+			"integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+			"dev": true
 		},
 		"path-key": {
 			"version": "3.1.1",
@@ -20604,42 +20410,6 @@
 			"integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
 			"dev": true
 		},
-		"swagger-jsdoc": {
-			"version": "6.2.8",
-			"resolved": "https://registry.npmjs.org/swagger-jsdoc/-/swagger-jsdoc-6.2.8.tgz",
-			"integrity": "sha512-VPvil1+JRpmJ55CgAtn8DIcpBs0bL5L3q5bVQvF4tAW/k/9JYSj7dCpaYCAv5rufe0vcCbBRQXGvzpkWjvLklQ==",
-			"requires": {
-				"commander": "6.2.0",
-				"doctrine": "3.0.0",
-				"glob": "7.1.6",
-				"lodash.mergewith": "^4.6.2",
-				"swagger-parser": "^10.0.3",
-				"yaml": "2.0.0-1"
-			},
-			"dependencies": {
-				"glob": {
-					"version": "7.1.6",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-					"integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
-					"requires": {
-						"fs.realpath": "^1.0.0",
-						"inflight": "^1.0.4",
-						"inherits": "2",
-						"minimatch": "^3.0.4",
-						"once": "^1.3.0",
-						"path-is-absolute": "^1.0.0"
-					}
-				}
-			}
-		},
-		"swagger-parser": {
-			"version": "10.0.3",
-			"resolved": "https://registry.npmjs.org/swagger-parser/-/swagger-parser-10.0.3.tgz",
-			"integrity": "sha512-nF7oMeL4KypldrQhac8RyHerJeGPD1p2xDh900GPvc+Nk7nWP6jX2FcC7WmkinMoAmoO774+AFXcWsW8gMWEIg==",
-			"requires": {
-				"@apidevtools/swagger-parser": "10.0.3"
-			}
-		},
 		"swagger-ui-dist": {
 			"version": "4.18.3",
 			"resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-4.18.3.tgz",
@@ -21113,11 +20883,6 @@
 				"builtins": "^1.0.3"
 			}
 		},
-		"validator": {
-			"version": "13.9.0",
-			"resolved": "https://registry.npmjs.org/validator/-/validator-13.9.0.tgz",
-			"integrity": "sha512-B+dGG8U3fdtM0/aNK4/X8CXq/EcxU2WPrPEkJGslb47qyHsxmbggTWK0yEA4qnYVNF+nxNlN88o14hIcPmSIEA=="
-		},
 		"vary": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -21200,7 +20965,8 @@
 		"wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+			"dev": true
 		},
 		"write-file-atomic": {
 			"version": "4.0.2",
@@ -21254,9 +21020,9 @@
 			"dev": true
 		},
 		"yaml": {
-			"version": "2.0.0-1",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.0.0-1.tgz",
-			"integrity": "sha512-W7h5dEhywMKenDJh2iX/LABkbFnBxasD27oyXWDS/feDsxiw0dD5ncXdYXgkvAsXIY2MpW/ZKkr9IU30DBdMNQ=="
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.0.tgz",
+			"integrity": "sha512-8/1wgzdKc7bc9E6my5wZjmdavHLvO/QOmLG1FBugblEvY4IXrLjlViIOmL24HthU042lWTDRO90Fz1Yp66UnMw=="
 		},
 		"yaml-ast-parser": {
 			"version": "0.0.43",
@@ -21334,25 +21100,6 @@
 			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
 			"integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
 			"dev": true
-		},
-		"z-schema": {
-			"version": "5.0.5",
-			"resolved": "https://registry.npmjs.org/z-schema/-/z-schema-5.0.5.tgz",
-			"integrity": "sha512-D7eujBWkLa3p2sIpJA0d1pr7es+a7m0vFAnZLlCEKq/Ij2k0MLi9Br2UPxoxdYystm5K1yeBGzub0FlYUEWj2Q==",
-			"requires": {
-				"commander": "^9.4.1",
-				"lodash.get": "^4.4.2",
-				"lodash.isequal": "^4.5.0",
-				"validator": "^13.7.0"
-			},
-			"dependencies": {
-				"commander": {
-					"version": "9.5.0",
-					"resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
-					"integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
-					"optional": true
-				}
-			}
 		},
 		"zip-stream": {
 			"version": "4.1.0",

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -35,6 +35,7 @@
 				"pino-pretty": "^10.0.0",
 				"prettier": "^2.8.8",
 				"serverless": "^3.31.0",
+				"serverless-dotenv-plugin": "^6.0.0",
 				"serverless-plugin-typescript": "^2.1.4",
 				"ts-jest": "^29.1.0",
 				"ts-node": "^10.9.1",
@@ -10330,6 +10331,20 @@
 				"node": ">=12.0"
 			}
 		},
+		"node_modules/serverless-dotenv-plugin": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/serverless-dotenv-plugin/-/serverless-dotenv-plugin-6.0.0.tgz",
+			"integrity": "sha512-8tLVNwHfDO0sBz6+m+DLTZquRk0AZq9rzqk3kphm1iIWKfan9R7RKt4hdq3eQ0kmDoqzudjPYBEXAJ5bUNKeGQ==",
+			"dev": true,
+			"dependencies": {
+				"chalk": "^4.1.2",
+				"dotenv": "^16.0.3",
+				"dotenv-expand": "^10.0.0"
+			},
+			"peerDependencies": {
+				"serverless": "1 || 2 || pre-3 || 3"
+			}
+		},
 		"node_modules/serverless-plugin-typescript": {
 			"version": "2.1.4",
 			"resolved": "https://registry.npmjs.org/serverless-plugin-typescript/-/serverless-plugin-typescript-2.1.4.tgz",
@@ -20179,6 +20194,17 @@
 						"has-flag": "^4.0.0"
 					}
 				}
+			}
+		},
+		"serverless-dotenv-plugin": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/serverless-dotenv-plugin/-/serverless-dotenv-plugin-6.0.0.tgz",
+			"integrity": "sha512-8tLVNwHfDO0sBz6+m+DLTZquRk0AZq9rzqk3kphm1iIWKfan9R7RKt4hdq3eQ0kmDoqzudjPYBEXAJ5bUNKeGQ==",
+			"dev": true,
+			"requires": {
+				"chalk": "^4.1.2",
+				"dotenv": "^16.0.3",
+				"dotenv-expand": "^10.0.0"
 			}
 		},
 		"serverless-plugin-typescript": {

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -8,8 +8,10 @@
 			"name": "backend",
 			"version": "0.0.1",
 			"dependencies": {
+				"@aws-sdk/client-lambda": "^3.338.0",
 				"@vendia/serverless-express": "^4.10.4",
 				"body-parser": "^1.20.2",
+				"celebrate": "^15.0.1",
 				"convict": "^6.2.4",
 				"dotenv": "^16.0.3",
 				"express": "^4.18.2",
@@ -91,6 +93,1346 @@
 			"peerDependencies": {
 				"openapi-types": ">=7"
 			}
+		},
+		"node_modules/@aws-crypto/crc32": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-3.0.0.tgz",
+			"integrity": "sha512-IzSgsrxUcsrejQbPVilIKy16kAT52EwB6zSaI+M3xxIhKh5+aldEyvI+z6erM7TCLB2BJsFrtHjp6/4/sr+3dA==",
+			"dependencies": {
+				"@aws-crypto/util": "^3.0.0",
+				"@aws-sdk/types": "^3.222.0",
+				"tslib": "^1.11.1"
+			}
+		},
+		"node_modules/@aws-crypto/ie11-detection": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
+			"integrity": "sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==",
+			"dependencies": {
+				"tslib": "^1.11.1"
+			}
+		},
+		"node_modules/@aws-crypto/sha256-browser": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz",
+			"integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
+			"dependencies": {
+				"@aws-crypto/ie11-detection": "^3.0.0",
+				"@aws-crypto/sha256-js": "^3.0.0",
+				"@aws-crypto/supports-web-crypto": "^3.0.0",
+				"@aws-crypto/util": "^3.0.0",
+				"@aws-sdk/types": "^3.222.0",
+				"@aws-sdk/util-locate-window": "^3.0.0",
+				"@aws-sdk/util-utf8-browser": "^3.0.0",
+				"tslib": "^1.11.1"
+			}
+		},
+		"node_modules/@aws-crypto/sha256-js": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
+			"integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
+			"dependencies": {
+				"@aws-crypto/util": "^3.0.0",
+				"@aws-sdk/types": "^3.222.0",
+				"tslib": "^1.11.1"
+			}
+		},
+		"node_modules/@aws-crypto/supports-web-crypto": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz",
+			"integrity": "sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==",
+			"dependencies": {
+				"tslib": "^1.11.1"
+			}
+		},
+		"node_modules/@aws-crypto/util": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
+			"integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
+			"dependencies": {
+				"@aws-sdk/types": "^3.222.0",
+				"@aws-sdk/util-utf8-browser": "^3.0.0",
+				"tslib": "^1.11.1"
+			}
+		},
+		"node_modules/@aws-sdk/abort-controller": {
+			"version": "3.338.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.338.0.tgz",
+			"integrity": "sha512-/yLI32+HwFNBRJ39jMXw+/cn3AnlCuJpQd7Ax4887g32Dgte5eyrfY8sJUOL6902BUmAq4oSRI5QeBXNplO0Xw==",
+			"dependencies": {
+				"@aws-sdk/types": "3.338.0",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/abort-controller/node_modules/tslib": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+			"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+		},
+		"node_modules/@aws-sdk/client-lambda": {
+			"version": "3.338.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-lambda/-/client-lambda-3.338.0.tgz",
+			"integrity": "sha512-Xq/9c7d4y4wG9SQyAKzw8bSc2q7B2rYiZqFmOocrqU3J8poH/yYpAxps/lWurlF7LJ3d09SMw2rzZR9eMckGbw==",
+			"dependencies": {
+				"@aws-crypto/sha256-browser": "3.0.0",
+				"@aws-crypto/sha256-js": "3.0.0",
+				"@aws-sdk/client-sts": "3.338.0",
+				"@aws-sdk/config-resolver": "3.338.0",
+				"@aws-sdk/credential-provider-node": "3.338.0",
+				"@aws-sdk/eventstream-serde-browser": "3.338.0",
+				"@aws-sdk/eventstream-serde-config-resolver": "3.338.0",
+				"@aws-sdk/eventstream-serde-node": "3.338.0",
+				"@aws-sdk/fetch-http-handler": "3.338.0",
+				"@aws-sdk/hash-node": "3.338.0",
+				"@aws-sdk/invalid-dependency": "3.338.0",
+				"@aws-sdk/middleware-content-length": "3.338.0",
+				"@aws-sdk/middleware-endpoint": "3.338.0",
+				"@aws-sdk/middleware-host-header": "3.338.0",
+				"@aws-sdk/middleware-logger": "3.338.0",
+				"@aws-sdk/middleware-recursion-detection": "3.338.0",
+				"@aws-sdk/middleware-retry": "3.338.0",
+				"@aws-sdk/middleware-serde": "3.338.0",
+				"@aws-sdk/middleware-signing": "3.338.0",
+				"@aws-sdk/middleware-stack": "3.338.0",
+				"@aws-sdk/middleware-user-agent": "3.338.0",
+				"@aws-sdk/node-config-provider": "3.338.0",
+				"@aws-sdk/node-http-handler": "3.338.0",
+				"@aws-sdk/smithy-client": "3.338.0",
+				"@aws-sdk/types": "3.338.0",
+				"@aws-sdk/url-parser": "3.338.0",
+				"@aws-sdk/util-base64": "3.310.0",
+				"@aws-sdk/util-body-length-browser": "3.310.0",
+				"@aws-sdk/util-body-length-node": "3.310.0",
+				"@aws-sdk/util-defaults-mode-browser": "3.338.0",
+				"@aws-sdk/util-defaults-mode-node": "3.338.0",
+				"@aws-sdk/util-endpoints": "3.338.0",
+				"@aws-sdk/util-retry": "3.338.0",
+				"@aws-sdk/util-user-agent-browser": "3.338.0",
+				"@aws-sdk/util-user-agent-node": "3.338.0",
+				"@aws-sdk/util-utf8": "3.310.0",
+				"@aws-sdk/util-waiter": "3.338.0",
+				"@smithy/protocol-http": "^1.0.1",
+				"@smithy/types": "^1.0.0",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-lambda/node_modules/tslib": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+			"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+		},
+		"node_modules/@aws-sdk/client-sso": {
+			"version": "3.338.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.338.0.tgz",
+			"integrity": "sha512-EglKsGlVph65PuFPKq1nGlxsY99XM2xHJaB1uX0bQEC94qrmS/M4a5kno5tiUnTWO1K+K4JBQiOxdGJs0GUS+w==",
+			"dependencies": {
+				"@aws-crypto/sha256-browser": "3.0.0",
+				"@aws-crypto/sha256-js": "3.0.0",
+				"@aws-sdk/config-resolver": "3.338.0",
+				"@aws-sdk/fetch-http-handler": "3.338.0",
+				"@aws-sdk/hash-node": "3.338.0",
+				"@aws-sdk/invalid-dependency": "3.338.0",
+				"@aws-sdk/middleware-content-length": "3.338.0",
+				"@aws-sdk/middleware-endpoint": "3.338.0",
+				"@aws-sdk/middleware-host-header": "3.338.0",
+				"@aws-sdk/middleware-logger": "3.338.0",
+				"@aws-sdk/middleware-recursion-detection": "3.338.0",
+				"@aws-sdk/middleware-retry": "3.338.0",
+				"@aws-sdk/middleware-serde": "3.338.0",
+				"@aws-sdk/middleware-stack": "3.338.0",
+				"@aws-sdk/middleware-user-agent": "3.338.0",
+				"@aws-sdk/node-config-provider": "3.338.0",
+				"@aws-sdk/node-http-handler": "3.338.0",
+				"@aws-sdk/smithy-client": "3.338.0",
+				"@aws-sdk/types": "3.338.0",
+				"@aws-sdk/url-parser": "3.338.0",
+				"@aws-sdk/util-base64": "3.310.0",
+				"@aws-sdk/util-body-length-browser": "3.310.0",
+				"@aws-sdk/util-body-length-node": "3.310.0",
+				"@aws-sdk/util-defaults-mode-browser": "3.338.0",
+				"@aws-sdk/util-defaults-mode-node": "3.338.0",
+				"@aws-sdk/util-endpoints": "3.338.0",
+				"@aws-sdk/util-retry": "3.338.0",
+				"@aws-sdk/util-user-agent-browser": "3.338.0",
+				"@aws-sdk/util-user-agent-node": "3.338.0",
+				"@aws-sdk/util-utf8": "3.310.0",
+				"@smithy/protocol-http": "^1.0.1",
+				"@smithy/types": "^1.0.0",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-sso-oidc": {
+			"version": "3.338.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.338.0.tgz",
+			"integrity": "sha512-mny5Q3LWKTcMMFS8WxeOCTinl193z7vS3b+eQz09K4jb1Lq04Bpjw25cySgBnhMGZ7QHQiYBscNLyu/TfOKiHA==",
+			"dependencies": {
+				"@aws-crypto/sha256-browser": "3.0.0",
+				"@aws-crypto/sha256-js": "3.0.0",
+				"@aws-sdk/config-resolver": "3.338.0",
+				"@aws-sdk/fetch-http-handler": "3.338.0",
+				"@aws-sdk/hash-node": "3.338.0",
+				"@aws-sdk/invalid-dependency": "3.338.0",
+				"@aws-sdk/middleware-content-length": "3.338.0",
+				"@aws-sdk/middleware-endpoint": "3.338.0",
+				"@aws-sdk/middleware-host-header": "3.338.0",
+				"@aws-sdk/middleware-logger": "3.338.0",
+				"@aws-sdk/middleware-recursion-detection": "3.338.0",
+				"@aws-sdk/middleware-retry": "3.338.0",
+				"@aws-sdk/middleware-serde": "3.338.0",
+				"@aws-sdk/middleware-stack": "3.338.0",
+				"@aws-sdk/middleware-user-agent": "3.338.0",
+				"@aws-sdk/node-config-provider": "3.338.0",
+				"@aws-sdk/node-http-handler": "3.338.0",
+				"@aws-sdk/smithy-client": "3.338.0",
+				"@aws-sdk/types": "3.338.0",
+				"@aws-sdk/url-parser": "3.338.0",
+				"@aws-sdk/util-base64": "3.310.0",
+				"@aws-sdk/util-body-length-browser": "3.310.0",
+				"@aws-sdk/util-body-length-node": "3.310.0",
+				"@aws-sdk/util-defaults-mode-browser": "3.338.0",
+				"@aws-sdk/util-defaults-mode-node": "3.338.0",
+				"@aws-sdk/util-endpoints": "3.338.0",
+				"@aws-sdk/util-retry": "3.338.0",
+				"@aws-sdk/util-user-agent-browser": "3.338.0",
+				"@aws-sdk/util-user-agent-node": "3.338.0",
+				"@aws-sdk/util-utf8": "3.310.0",
+				"@smithy/protocol-http": "^1.0.1",
+				"@smithy/types": "^1.0.0",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-sso-oidc/node_modules/tslib": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+			"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+		},
+		"node_modules/@aws-sdk/client-sso/node_modules/tslib": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+			"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+		},
+		"node_modules/@aws-sdk/client-sts": {
+			"version": "3.338.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.338.0.tgz",
+			"integrity": "sha512-FBHy/G7BAPX0CdEeeGYpoAnKXVCSIIkESLU2wF6x880z+U2IqiL48Fzoa5qoLaLPQaK/30P7ytznkqm4vd1OFw==",
+			"dependencies": {
+				"@aws-crypto/sha256-browser": "3.0.0",
+				"@aws-crypto/sha256-js": "3.0.0",
+				"@aws-sdk/config-resolver": "3.338.0",
+				"@aws-sdk/credential-provider-node": "3.338.0",
+				"@aws-sdk/fetch-http-handler": "3.338.0",
+				"@aws-sdk/hash-node": "3.338.0",
+				"@aws-sdk/invalid-dependency": "3.338.0",
+				"@aws-sdk/middleware-content-length": "3.338.0",
+				"@aws-sdk/middleware-endpoint": "3.338.0",
+				"@aws-sdk/middleware-host-header": "3.338.0",
+				"@aws-sdk/middleware-logger": "3.338.0",
+				"@aws-sdk/middleware-recursion-detection": "3.338.0",
+				"@aws-sdk/middleware-retry": "3.338.0",
+				"@aws-sdk/middleware-sdk-sts": "3.338.0",
+				"@aws-sdk/middleware-serde": "3.338.0",
+				"@aws-sdk/middleware-signing": "3.338.0",
+				"@aws-sdk/middleware-stack": "3.338.0",
+				"@aws-sdk/middleware-user-agent": "3.338.0",
+				"@aws-sdk/node-config-provider": "3.338.0",
+				"@aws-sdk/node-http-handler": "3.338.0",
+				"@aws-sdk/smithy-client": "3.338.0",
+				"@aws-sdk/types": "3.338.0",
+				"@aws-sdk/url-parser": "3.338.0",
+				"@aws-sdk/util-base64": "3.310.0",
+				"@aws-sdk/util-body-length-browser": "3.310.0",
+				"@aws-sdk/util-body-length-node": "3.310.0",
+				"@aws-sdk/util-defaults-mode-browser": "3.338.0",
+				"@aws-sdk/util-defaults-mode-node": "3.338.0",
+				"@aws-sdk/util-endpoints": "3.338.0",
+				"@aws-sdk/util-retry": "3.338.0",
+				"@aws-sdk/util-user-agent-browser": "3.338.0",
+				"@aws-sdk/util-user-agent-node": "3.338.0",
+				"@aws-sdk/util-utf8": "3.310.0",
+				"@smithy/protocol-http": "^1.0.1",
+				"@smithy/types": "^1.0.0",
+				"fast-xml-parser": "4.1.2",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-sts/node_modules/tslib": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+			"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+		},
+		"node_modules/@aws-sdk/config-resolver": {
+			"version": "3.338.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.338.0.tgz",
+			"integrity": "sha512-rB9WUaMfTB74Hd2mOiyPFR7Q1viT+w6SaDSR9SA1P8EeIg5H13FNdIKb736Z8/6QJhDj7whdyk1CTGV+DmXOOg==",
+			"dependencies": {
+				"@aws-sdk/types": "3.338.0",
+				"@aws-sdk/util-config-provider": "3.310.0",
+				"@aws-sdk/util-middleware": "3.338.0",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/config-resolver/node_modules/tslib": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+			"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+		},
+		"node_modules/@aws-sdk/credential-provider-env": {
+			"version": "3.338.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.338.0.tgz",
+			"integrity": "sha512-j14vApy80tpk87C3x3uBf1caQsuR8RdQ8iOW830H/AOhsa88XaZIB/NQSX7exaIKZa2RU0Vv2wIlGAA8ko7J6g==",
+			"dependencies": {
+				"@aws-sdk/property-provider": "3.338.0",
+				"@aws-sdk/types": "3.338.0",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-env/node_modules/tslib": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+			"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+		},
+		"node_modules/@aws-sdk/credential-provider-imds": {
+			"version": "3.338.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.338.0.tgz",
+			"integrity": "sha512-qsqeywYfJevg5pgUUUBmm7pK1bckVrl091PZB2IliFdQVnDvI5GFLf4B0oZqjaLAzPG1gVtxRvqIve+tnP/+xA==",
+			"dependencies": {
+				"@aws-sdk/node-config-provider": "3.338.0",
+				"@aws-sdk/property-provider": "3.338.0",
+				"@aws-sdk/types": "3.338.0",
+				"@aws-sdk/url-parser": "3.338.0",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-imds/node_modules/tslib": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+			"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+		},
+		"node_modules/@aws-sdk/credential-provider-ini": {
+			"version": "3.338.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.338.0.tgz",
+			"integrity": "sha512-UhgYgymT9sJiRm0peqP5EvtR4dXiS2Q2AuFgDUjBvDz8JaZlqafsIS4cfyGwTHV/xY6cdiMu5rCTe8hTyXsukQ==",
+			"dependencies": {
+				"@aws-sdk/credential-provider-env": "3.338.0",
+				"@aws-sdk/credential-provider-imds": "3.338.0",
+				"@aws-sdk/credential-provider-process": "3.338.0",
+				"@aws-sdk/credential-provider-sso": "3.338.0",
+				"@aws-sdk/credential-provider-web-identity": "3.338.0",
+				"@aws-sdk/property-provider": "3.338.0",
+				"@aws-sdk/shared-ini-file-loader": "3.338.0",
+				"@aws-sdk/types": "3.338.0",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-ini/node_modules/tslib": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+			"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+		},
+		"node_modules/@aws-sdk/credential-provider-node": {
+			"version": "3.338.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.338.0.tgz",
+			"integrity": "sha512-nZjaMRxJqX0EXMV9LA5IbRQI1pDGGZiPYX2KDfZ1Y9Gc1Y/vIZhHKOHGb1uKMAonlR076CsXlev4/tjC8SGGuw==",
+			"dependencies": {
+				"@aws-sdk/credential-provider-env": "3.338.0",
+				"@aws-sdk/credential-provider-imds": "3.338.0",
+				"@aws-sdk/credential-provider-ini": "3.338.0",
+				"@aws-sdk/credential-provider-process": "3.338.0",
+				"@aws-sdk/credential-provider-sso": "3.338.0",
+				"@aws-sdk/credential-provider-web-identity": "3.338.0",
+				"@aws-sdk/property-provider": "3.338.0",
+				"@aws-sdk/shared-ini-file-loader": "3.338.0",
+				"@aws-sdk/types": "3.338.0",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-node/node_modules/tslib": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+			"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+		},
+		"node_modules/@aws-sdk/credential-provider-process": {
+			"version": "3.338.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.338.0.tgz",
+			"integrity": "sha512-5I1EgJxFFEg8xel2kInMpkdBKajUut0hR2fBajqCmK7Pflu8s0I2NKDots9a3YJagNrFJq38+EzoDcUvRrd2dg==",
+			"dependencies": {
+				"@aws-sdk/property-provider": "3.338.0",
+				"@aws-sdk/shared-ini-file-loader": "3.338.0",
+				"@aws-sdk/types": "3.338.0",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-process/node_modules/tslib": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+			"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+		},
+		"node_modules/@aws-sdk/credential-provider-sso": {
+			"version": "3.338.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.338.0.tgz",
+			"integrity": "sha512-fpzYHK17iF/uFkrm4cLg/utDVKSBTWNjAiNlE3GF6CaixBCwc0QBLKHk2nG4d1ZZeMVCbIUMS7eoqfR0LYc/yw==",
+			"dependencies": {
+				"@aws-sdk/client-sso": "3.338.0",
+				"@aws-sdk/property-provider": "3.338.0",
+				"@aws-sdk/shared-ini-file-loader": "3.338.0",
+				"@aws-sdk/token-providers": "3.338.0",
+				"@aws-sdk/types": "3.338.0",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-sso/node_modules/tslib": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+			"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+		},
+		"node_modules/@aws-sdk/credential-provider-web-identity": {
+			"version": "3.338.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.338.0.tgz",
+			"integrity": "sha512-kjT/P18jM1icwjYwr8wfY//T8lv2s81ms7OC7vgiSqckmQOxpVkdsep9d44ymSUXwopmotFP7M9gGnEHS6HwAA==",
+			"dependencies": {
+				"@aws-sdk/property-provider": "3.338.0",
+				"@aws-sdk/types": "3.338.0",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-web-identity/node_modules/tslib": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+			"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+		},
+		"node_modules/@aws-sdk/eventstream-codec": {
+			"version": "3.338.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-codec/-/eventstream-codec-3.338.0.tgz",
+			"integrity": "sha512-D9nxnkuY6ArIr+b2Gfc0YExWgNbzgfLIljgcBawL9P4vkkE0uZgPM0fF0Paug2DpkuSluHS6PCLaM/nLbBiLAQ==",
+			"dependencies": {
+				"@aws-crypto/crc32": "3.0.0",
+				"@aws-sdk/types": "3.338.0",
+				"@aws-sdk/util-hex-encoding": "3.310.0",
+				"tslib": "^2.5.0"
+			}
+		},
+		"node_modules/@aws-sdk/eventstream-codec/node_modules/tslib": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+			"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+		},
+		"node_modules/@aws-sdk/eventstream-serde-browser": {
+			"version": "3.338.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-browser/-/eventstream-serde-browser-3.338.0.tgz",
+			"integrity": "sha512-SRaFPJpCPOghZ9vuStSBzwvVqEX0DSVQl4j1vq/9mHUj1a4Xn0qH29eLBxsyB5NOQNb46RMdd8UTNgNSnCI74w==",
+			"dependencies": {
+				"@aws-sdk/eventstream-serde-universal": "3.338.0",
+				"@aws-sdk/types": "3.338.0",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/eventstream-serde-browser/node_modules/tslib": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+			"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+		},
+		"node_modules/@aws-sdk/eventstream-serde-config-resolver": {
+			"version": "3.338.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.338.0.tgz",
+			"integrity": "sha512-utid/nDd6IoPXWwz/mCnAwWWNgntK53feRLsztyWg7GHJabXli/kXo6U/3+Mn7Q2RS4eAASpqhYXXrVni5SgTA==",
+			"dependencies": {
+				"@aws-sdk/types": "3.338.0",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/eventstream-serde-config-resolver/node_modules/tslib": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+			"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+		},
+		"node_modules/@aws-sdk/eventstream-serde-node": {
+			"version": "3.338.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-node/-/eventstream-serde-node-3.338.0.tgz",
+			"integrity": "sha512-Fwnrgaa6rs/0HMD3NVk1FcxZqgtG5xZz9qIlSLt5JFIG/rpBTrMREi+KIhLHvd3/4ZhkdLjX7y+ml8K6atSveA==",
+			"dependencies": {
+				"@aws-sdk/eventstream-serde-universal": "3.338.0",
+				"@aws-sdk/types": "3.338.0",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/eventstream-serde-node/node_modules/tslib": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+			"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+		},
+		"node_modules/@aws-sdk/eventstream-serde-universal": {
+			"version": "3.338.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-universal/-/eventstream-serde-universal-3.338.0.tgz",
+			"integrity": "sha512-uuHu1nksdPPevuSUkq5aOo7j1Zb6IRSuQ0fV0zuolg2i1B2wAQjrkWH9EcvGzOe0/yWEQF3ohggczuovn4yCzQ==",
+			"dependencies": {
+				"@aws-sdk/eventstream-codec": "3.338.0",
+				"@aws-sdk/types": "3.338.0",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/eventstream-serde-universal/node_modules/tslib": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+			"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+		},
+		"node_modules/@aws-sdk/fetch-http-handler": {
+			"version": "3.338.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.338.0.tgz",
+			"integrity": "sha512-NOIQmeSa51J2nFAzl99IjxwQkq27cdNJzF59jQWzpUCGbxXfMD4WWy2NHubabSFuJ4FJU2eyoQHUNUFc6/uxXA==",
+			"dependencies": {
+				"@aws-sdk/protocol-http": "3.338.0",
+				"@aws-sdk/querystring-builder": "3.338.0",
+				"@aws-sdk/types": "3.338.0",
+				"@aws-sdk/util-base64": "3.310.0",
+				"tslib": "^2.5.0"
+			}
+		},
+		"node_modules/@aws-sdk/fetch-http-handler/node_modules/tslib": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+			"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+		},
+		"node_modules/@aws-sdk/hash-node": {
+			"version": "3.338.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.338.0.tgz",
+			"integrity": "sha512-udveX3ZRO1oUbyBTQH0LJ8Ika7uk0pHuXrqapdi66GGRJB50IhmOg372zUEwZjDB7DZYXfGTCuAj2OoEalgpBA==",
+			"dependencies": {
+				"@aws-sdk/types": "3.338.0",
+				"@aws-sdk/util-buffer-from": "3.310.0",
+				"@aws-sdk/util-utf8": "3.310.0",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/hash-node/node_modules/tslib": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+			"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+		},
+		"node_modules/@aws-sdk/invalid-dependency": {
+			"version": "3.338.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.338.0.tgz",
+			"integrity": "sha512-m6r1fTTGSl0V6l8Z+Ii4Ei8VFpDmu0AT6A59ZhJaMZgxf925ywuCPydyDW9ZqTLE0e7CgxhEHEsH1+HzpVuHTw==",
+			"dependencies": {
+				"@aws-sdk/types": "3.338.0",
+				"tslib": "^2.5.0"
+			}
+		},
+		"node_modules/@aws-sdk/invalid-dependency/node_modules/tslib": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+			"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+		},
+		"node_modules/@aws-sdk/is-array-buffer": {
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.310.0.tgz",
+			"integrity": "sha512-urnbcCR+h9NWUnmOtet/s4ghvzsidFmspfhYaHAmSRdy9yDjdjBJMFjjsn85A1ODUktztm+cVncXjQ38WCMjMQ==",
+			"dependencies": {
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/is-array-buffer/node_modules/tslib": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+			"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+		},
+		"node_modules/@aws-sdk/middleware-content-length": {
+			"version": "3.338.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.338.0.tgz",
+			"integrity": "sha512-m2C+yJaNmbA3ocBp/7ImUUuimymV5JsFdV7yAibpbYMX22g3q83nieOF9x0I66J0+h+/bcriz/T1ZJAPANLz/g==",
+			"dependencies": {
+				"@aws-sdk/protocol-http": "3.338.0",
+				"@aws-sdk/types": "3.338.0",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-content-length/node_modules/tslib": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+			"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+		},
+		"node_modules/@aws-sdk/middleware-endpoint": {
+			"version": "3.338.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.338.0.tgz",
+			"integrity": "sha512-bzL9Q8lFidg2NTjGVGDKI6yPG/XiPS+VIAMHJeihQmcv1alIy+N3IL4bEN15Fg+cwaGm+P3BevcLIHmcCOVb4w==",
+			"dependencies": {
+				"@aws-sdk/middleware-serde": "3.338.0",
+				"@aws-sdk/types": "3.338.0",
+				"@aws-sdk/url-parser": "3.338.0",
+				"@aws-sdk/util-middleware": "3.338.0",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-endpoint/node_modules/tslib": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+			"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+		},
+		"node_modules/@aws-sdk/middleware-host-header": {
+			"version": "3.338.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.338.0.tgz",
+			"integrity": "sha512-k3C7oppkrqeKrAJt9XIl45SdELtnph9BF0QypjyRfT5MNEDnMMsQkc6xy3ZMqG5dWQq6B2l8C+JL7pOvkSQP3w==",
+			"dependencies": {
+				"@aws-sdk/protocol-http": "3.338.0",
+				"@aws-sdk/types": "3.338.0",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-host-header/node_modules/tslib": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+			"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+		},
+		"node_modules/@aws-sdk/middleware-logger": {
+			"version": "3.338.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.338.0.tgz",
+			"integrity": "sha512-btj9U0Xovq/UAu3Ur4lAfF7Q3DvvwJ/0UUWsI6GgSzzqSOFgKCz7hCP2GZIT8aXEA5hJOpBOEMkNMjWPNa91Hg==",
+			"dependencies": {
+				"@aws-sdk/types": "3.338.0",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-logger/node_modules/tslib": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+			"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+		},
+		"node_modules/@aws-sdk/middleware-recursion-detection": {
+			"version": "3.338.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.338.0.tgz",
+			"integrity": "sha512-fu5KwiHHSqC8KTQH6xdJ9+dua4gQcXSFLE5fVsergqd0uVdsmhiI+IDfW6QNwF/lmCqnoKDkpeasuB98eG2tow==",
+			"dependencies": {
+				"@aws-sdk/protocol-http": "3.338.0",
+				"@aws-sdk/types": "3.338.0",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-recursion-detection/node_modules/tslib": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+			"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+		},
+		"node_modules/@aws-sdk/middleware-retry": {
+			"version": "3.338.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.338.0.tgz",
+			"integrity": "sha512-nw1oPFkB7TdDG4Vlz2Td47ft/2Gmx1bA18QfE9K1mMWZ4nnoAL8xnHbowlTfHo62+BbFCAPu53PzDUCncBL0iw==",
+			"dependencies": {
+				"@aws-sdk/protocol-http": "3.338.0",
+				"@aws-sdk/service-error-classification": "3.338.0",
+				"@aws-sdk/types": "3.338.0",
+				"@aws-sdk/util-middleware": "3.338.0",
+				"@aws-sdk/util-retry": "3.338.0",
+				"tslib": "^2.5.0",
+				"uuid": "^8.3.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-retry/node_modules/tslib": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+			"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+		},
+		"node_modules/@aws-sdk/middleware-retry/node_modules/uuid": {
+			"version": "8.3.2",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+			"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+			"bin": {
+				"uuid": "dist/bin/uuid"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-sdk-sts": {
+			"version": "3.338.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.338.0.tgz",
+			"integrity": "sha512-aZ8eFVaot8oYQri1wOesrA3gLizeAHtlA/ELlqxoGDJtO011J4/hTHTn0iJGbktaCvc1L3TF6mgOsgXpudYqMg==",
+			"dependencies": {
+				"@aws-sdk/middleware-signing": "3.338.0",
+				"@aws-sdk/types": "3.338.0",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-sdk-sts/node_modules/tslib": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+			"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+		},
+		"node_modules/@aws-sdk/middleware-serde": {
+			"version": "3.338.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.338.0.tgz",
+			"integrity": "sha512-AabRLrE6sk9tqQlQ7z3kn4gTHNN7Anjk/AM0ZEu96WcWjedcpgM1vVpKTBE7vjnxcTRNq0CEM3GLtQqaZ7/HjQ==",
+			"dependencies": {
+				"@aws-sdk/types": "3.338.0",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-serde/node_modules/tslib": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+			"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+		},
+		"node_modules/@aws-sdk/middleware-signing": {
+			"version": "3.338.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.338.0.tgz",
+			"integrity": "sha512-AprhhShMF75mOx80SABujLwrU/w2uHQIvWd6aF3BsE5JRI3uQZRqspfjFCaK52HNLQPj3sCQUw1GeiZJ8GyWCw==",
+			"dependencies": {
+				"@aws-sdk/property-provider": "3.338.0",
+				"@aws-sdk/protocol-http": "3.338.0",
+				"@aws-sdk/signature-v4": "3.338.0",
+				"@aws-sdk/types": "3.338.0",
+				"@aws-sdk/util-middleware": "3.338.0",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-signing/node_modules/tslib": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+			"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+		},
+		"node_modules/@aws-sdk/middleware-stack": {
+			"version": "3.338.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.338.0.tgz",
+			"integrity": "sha512-9zXyiklX9AK9ZIXuIPzWzz2vevBEcnBs9UNIxiHl4NBZ8d8oyTvaES1PtFuwL6f7ANSZ9EGVQ2rdTTnMNxMI1A==",
+			"dependencies": {
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-stack/node_modules/tslib": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+			"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+		},
+		"node_modules/@aws-sdk/middleware-user-agent": {
+			"version": "3.338.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.338.0.tgz",
+			"integrity": "sha512-DMqODOsDMFMPcDw2Ya6a0i34AhaBDRpp3vJ+FK3zPxUIsv6iHA+XqEcXLOxROLLoydoyxus7k2U+EWibLZrFbQ==",
+			"dependencies": {
+				"@aws-sdk/protocol-http": "3.338.0",
+				"@aws-sdk/types": "3.338.0",
+				"@aws-sdk/util-endpoints": "3.338.0",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-user-agent/node_modules/tslib": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+			"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+		},
+		"node_modules/@aws-sdk/node-config-provider": {
+			"version": "3.338.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.338.0.tgz",
+			"integrity": "sha512-YO7yWg3ipnUI5u6D+Zn2NUpjj5krwc8zNWeY79ULVIp9g7faqGX3xMSjeRSrpZ83s5jg1dOm/+bB0gw7mCrRCw==",
+			"dependencies": {
+				"@aws-sdk/property-provider": "3.338.0",
+				"@aws-sdk/shared-ini-file-loader": "3.338.0",
+				"@aws-sdk/types": "3.338.0",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/node-config-provider/node_modules/tslib": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+			"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+		},
+		"node_modules/@aws-sdk/node-http-handler": {
+			"version": "3.338.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.338.0.tgz",
+			"integrity": "sha512-V1BLzCruiv45tJ0vXjiamY8LncIsUFsXYJGDupomFYhWRN8L1MUB9f2vdKn5X3wXn/yKrluwTmNaryrIqd9akA==",
+			"dependencies": {
+				"@aws-sdk/abort-controller": "3.338.0",
+				"@aws-sdk/protocol-http": "3.338.0",
+				"@aws-sdk/querystring-builder": "3.338.0",
+				"@aws-sdk/types": "3.338.0",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/node-http-handler/node_modules/tslib": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+			"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+		},
+		"node_modules/@aws-sdk/property-provider": {
+			"version": "3.338.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.338.0.tgz",
+			"integrity": "sha512-mC+ZJ738ipif6ZkH59gcipozYj1FOfpXr9pGVCA2hJGLDdaBwI2Jfpb2qCqbsTNtoCjBuIy+sQHGmUHyclgYHg==",
+			"dependencies": {
+				"@aws-sdk/types": "3.338.0",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/property-provider/node_modules/tslib": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+			"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+		},
+		"node_modules/@aws-sdk/protocol-http": {
+			"version": "3.338.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.338.0.tgz",
+			"integrity": "sha512-JX03Q2gshdzOWtA/07kdpk0hqeOrOfwuF8TB97g66VCcIopYQkCeNH1zzkWu+RsGxfSlzQ7up+ZM6sclYXyB1A==",
+			"dependencies": {
+				"@aws-sdk/types": "3.338.0",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/protocol-http/node_modules/tslib": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+			"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+		},
+		"node_modules/@aws-sdk/querystring-builder": {
+			"version": "3.338.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.338.0.tgz",
+			"integrity": "sha512-IB3YhO93Htwt2SxJx4VWsN57Rt1KEsvZ6PbneO4bcS96E04BlfBujYMZ+QxEM3EJxorhpkwbI2QnI12IjD8FhA==",
+			"dependencies": {
+				"@aws-sdk/types": "3.338.0",
+				"@aws-sdk/util-uri-escape": "3.310.0",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/querystring-builder/node_modules/tslib": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+			"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+		},
+		"node_modules/@aws-sdk/querystring-parser": {
+			"version": "3.338.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.338.0.tgz",
+			"integrity": "sha512-vtI8Gqx4yj0BZlWonRMgLz68sHt5H48HN+ClnY+fDDB/8KLnCuwZ3TGKmYIbYbshL9wjJz0A9aLzuC6nPQ5JKw==",
+			"dependencies": {
+				"@aws-sdk/types": "3.338.0",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/querystring-parser/node_modules/tslib": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+			"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+		},
+		"node_modules/@aws-sdk/service-error-classification": {
+			"version": "3.338.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.338.0.tgz",
+			"integrity": "sha512-BJFr2mx/N3NbycGTlMMGRBc0tGcHXHEbMPy1H2RbejzL23zh27MchaL1WAK9SvwVMKS29hSDbhkuVR2ABRjerA==",
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/shared-ini-file-loader": {
+			"version": "3.338.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.338.0.tgz",
+			"integrity": "sha512-MA1Sp97LFlOXcUaXgo47j86IsPRWYq1V/JqR+uu0zofZw4Xlt7Y6F+mmnDHvuuMy6R2ltzjXSwgrrW3k0bxFPA==",
+			"dependencies": {
+				"@aws-sdk/types": "3.338.0",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/shared-ini-file-loader/node_modules/tslib": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+			"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+		},
+		"node_modules/@aws-sdk/signature-v4": {
+			"version": "3.338.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.338.0.tgz",
+			"integrity": "sha512-EwKTe/8Iwab/v0eo27w7DRYlqp9wEZEhuRfOMwTikUVH6iuTnW6AXjcIUfcRYBRbx2zqnRSiMAZkjN6ZFYm0bQ==",
+			"dependencies": {
+				"@aws-sdk/is-array-buffer": "3.310.0",
+				"@aws-sdk/types": "3.338.0",
+				"@aws-sdk/util-hex-encoding": "3.310.0",
+				"@aws-sdk/util-middleware": "3.338.0",
+				"@aws-sdk/util-uri-escape": "3.310.0",
+				"@aws-sdk/util-utf8": "3.310.0",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/signature-v4/node_modules/tslib": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+			"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+		},
+		"node_modules/@aws-sdk/smithy-client": {
+			"version": "3.338.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.338.0.tgz",
+			"integrity": "sha512-IpFLdLG8GwaiFdqVXf+WyU47Hfa2BMIupAU6iSkE2ZO0lBdg+efn/BBwis5WbBNTDCaaU0xH9y68SmnqqtD7pA==",
+			"dependencies": {
+				"@aws-sdk/middleware-stack": "3.338.0",
+				"@aws-sdk/types": "3.338.0",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/smithy-client/node_modules/tslib": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+			"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+		},
+		"node_modules/@aws-sdk/token-providers": {
+			"version": "3.338.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.338.0.tgz",
+			"integrity": "sha512-wuiEGcWiMeq5N68M489i2iGYcCad9p1btNEOFgus+JO3DRSA6HZXizLI1wqfbUm5Ei8512AvUKB6N8PMzahQsg==",
+			"dependencies": {
+				"@aws-sdk/client-sso-oidc": "3.338.0",
+				"@aws-sdk/property-provider": "3.338.0",
+				"@aws-sdk/shared-ini-file-loader": "3.338.0",
+				"@aws-sdk/types": "3.338.0",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/token-providers/node_modules/tslib": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+			"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+		},
+		"node_modules/@aws-sdk/types": {
+			"version": "3.338.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.338.0.tgz",
+			"integrity": "sha512-hrNK15o+EObLrl9oWOyxJN2dwjgbdBMGolLEVP/wR/+M9ojHgk/x1kMsCVcV82a8Vgdtqx1TyOC3UugUPT0+NA==",
+			"dependencies": {
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/types/node_modules/tslib": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+			"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+		},
+		"node_modules/@aws-sdk/url-parser": {
+			"version": "3.338.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.338.0.tgz",
+			"integrity": "sha512-x8a5swfZ6iWJZEA8rm99OKQ1A6xhWPP1taQUzoPavGCzPAOqyc8cd0FcXYMxvtXb3FeBhGaI8tiGKvelJro0+A==",
+			"dependencies": {
+				"@aws-sdk/querystring-parser": "3.338.0",
+				"@aws-sdk/types": "3.338.0",
+				"tslib": "^2.5.0"
+			}
+		},
+		"node_modules/@aws-sdk/url-parser/node_modules/tslib": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+			"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+		},
+		"node_modules/@aws-sdk/util-base64": {
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.310.0.tgz",
+			"integrity": "sha512-v3+HBKQvqgdzcbL+pFswlx5HQsd9L6ZTlyPVL2LS9nNXnCcR3XgGz9jRskikRUuUvUXtkSG1J88GAOnJ/apTPg==",
+			"dependencies": {
+				"@aws-sdk/util-buffer-from": "3.310.0",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/util-base64/node_modules/tslib": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+			"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+		},
+		"node_modules/@aws-sdk/util-body-length-browser": {
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.310.0.tgz",
+			"integrity": "sha512-sxsC3lPBGfpHtNTUoGXMQXLwjmR0zVpx0rSvzTPAuoVILVsp5AU/w5FphNPxD5OVIjNbZv9KsKTuvNTiZjDp9g==",
+			"dependencies": {
+				"tslib": "^2.5.0"
+			}
+		},
+		"node_modules/@aws-sdk/util-body-length-browser/node_modules/tslib": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+			"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+		},
+		"node_modules/@aws-sdk/util-body-length-node": {
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.310.0.tgz",
+			"integrity": "sha512-2tqGXdyKhyA6w4zz7UPoS8Ip+7sayOg9BwHNidiGm2ikbDxm1YrCfYXvCBdwaJxa4hJfRVz+aL9e+d3GqPI9pQ==",
+			"dependencies": {
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/util-body-length-node/node_modules/tslib": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+			"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+		},
+		"node_modules/@aws-sdk/util-buffer-from": {
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.310.0.tgz",
+			"integrity": "sha512-i6LVeXFtGih5Zs8enLrt+ExXY92QV25jtEnTKHsmlFqFAuL3VBeod6boeMXkN2p9lbSVVQ1sAOOYZOHYbYkntw==",
+			"dependencies": {
+				"@aws-sdk/is-array-buffer": "3.310.0",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/util-buffer-from/node_modules/tslib": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+			"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+		},
+		"node_modules/@aws-sdk/util-config-provider": {
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.310.0.tgz",
+			"integrity": "sha512-xIBaYo8dwiojCw8vnUcIL4Z5tyfb1v3yjqyJKJWV/dqKUFOOS0U591plmXbM+M/QkXyML3ypon1f8+BoaDExrg==",
+			"dependencies": {
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/util-config-provider/node_modules/tslib": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+			"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+		},
+		"node_modules/@aws-sdk/util-defaults-mode-browser": {
+			"version": "3.338.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.338.0.tgz",
+			"integrity": "sha512-Zfr5c7JKMJTfb7z+hgd0ioU5iw+wId6Cppc5V1HpZuS2YY4Mn3aJIixzyzhIoCzbmk/yIkf96981epM9eo3/TA==",
+			"dependencies": {
+				"@aws-sdk/property-provider": "3.338.0",
+				"@aws-sdk/types": "3.338.0",
+				"bowser": "^2.11.0",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">= 10.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/util-defaults-mode-browser/node_modules/tslib": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+			"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+		},
+		"node_modules/@aws-sdk/util-defaults-mode-node": {
+			"version": "3.338.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.338.0.tgz",
+			"integrity": "sha512-DFM3BSpSetshZTgTjueCkAYZWS0tn5zl7SjkSpFhWQZ8Tt/Df3/DEjcPvxzmC/5vgYSUXNsqcI7lLAJk9aGZAA==",
+			"dependencies": {
+				"@aws-sdk/config-resolver": "3.338.0",
+				"@aws-sdk/credential-provider-imds": "3.338.0",
+				"@aws-sdk/node-config-provider": "3.338.0",
+				"@aws-sdk/property-provider": "3.338.0",
+				"@aws-sdk/types": "3.338.0",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">= 10.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/util-defaults-mode-node/node_modules/tslib": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+			"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+		},
+		"node_modules/@aws-sdk/util-endpoints": {
+			"version": "3.338.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.338.0.tgz",
+			"integrity": "sha512-0gBQcohbNcBsBR7oyaD0Dg2m6qOmfp0G1iN/NM23gwAr2H3ni8tUXfs1HsZzxikOwUr6dSLASokc30vQXBF44A==",
+			"dependencies": {
+				"@aws-sdk/types": "3.338.0",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/util-endpoints/node_modules/tslib": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+			"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+		},
+		"node_modules/@aws-sdk/util-hex-encoding": {
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.310.0.tgz",
+			"integrity": "sha512-sVN7mcCCDSJ67pI1ZMtk84SKGqyix6/0A1Ab163YKn+lFBQRMKexleZzpYzNGxYzmQS6VanP/cfU7NiLQOaSfA==",
+			"dependencies": {
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/util-hex-encoding/node_modules/tslib": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+			"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+		},
+		"node_modules/@aws-sdk/util-locate-window": {
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.310.0.tgz",
+			"integrity": "sha512-qo2t/vBTnoXpjKxlsC2e1gBrRm80M3bId27r0BRB2VniSSe7bL1mmzM+/HFtujm0iAxtPM+aLEflLJlJeDPg0w==",
+			"dependencies": {
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/util-locate-window/node_modules/tslib": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+			"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+		},
+		"node_modules/@aws-sdk/util-middleware": {
+			"version": "3.338.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.338.0.tgz",
+			"integrity": "sha512-oQuAmhi16HWEqVa+Nq4VD4Ymet9vS+uiW92reaagQrW2QFjAgJW9A6pU0PcIHF9sWY1iDKeNdV5b9odQ45PDJA==",
+			"dependencies": {
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/util-middleware/node_modules/tslib": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+			"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+		},
+		"node_modules/@aws-sdk/util-retry": {
+			"version": "3.338.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.338.0.tgz",
+			"integrity": "sha512-diR6M3gJgSgBg/87L2e8iF8urG+LOW9ZGWxhntYpYX4uhiIjwNgUPUa993553C8GIOZDHez5X9ExU4asYGQ71Q==",
+			"dependencies": {
+				"@aws-sdk/service-error-classification": "3.338.0",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">= 14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/util-retry/node_modules/tslib": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+			"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+		},
+		"node_modules/@aws-sdk/util-uri-escape": {
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.310.0.tgz",
+			"integrity": "sha512-drzt+aB2qo2LgtDoiy/3sVG8w63cgLkqFIa2NFlGpUgHFWTXkqtbgf4L5QdjRGKWhmZsnqkbtL7vkSWEcYDJ4Q==",
+			"dependencies": {
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/util-uri-escape/node_modules/tslib": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+			"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+		},
+		"node_modules/@aws-sdk/util-user-agent-browser": {
+			"version": "3.338.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.338.0.tgz",
+			"integrity": "sha512-3e8D+SOtOQEtRtksOEF7EC26xPkuY6YK6biLgdtvR9JspK96rHk5eX1HEJeBJJqbxhyPaxpIw+OhWhnsrUS3hA==",
+			"dependencies": {
+				"@aws-sdk/types": "3.338.0",
+				"bowser": "^2.11.0",
+				"tslib": "^2.5.0"
+			}
+		},
+		"node_modules/@aws-sdk/util-user-agent-browser/node_modules/tslib": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+			"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+		},
+		"node_modules/@aws-sdk/util-user-agent-node": {
+			"version": "3.338.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.338.0.tgz",
+			"integrity": "sha512-rc+bC5KM9h25urRc+MXuViJkJ+qYG2NlCRw6xm2lSIvHFJTUjH1ZMO3mqNDYkGnQRbj0mmrVe+N77TJZGf3Q2Q==",
+			"dependencies": {
+				"@aws-sdk/node-config-provider": "3.338.0",
+				"@aws-sdk/types": "3.338.0",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			},
+			"peerDependencies": {
+				"aws-crt": ">=1.0.0"
+			},
+			"peerDependenciesMeta": {
+				"aws-crt": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@aws-sdk/util-user-agent-node/node_modules/tslib": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+			"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+		},
+		"node_modules/@aws-sdk/util-utf8": {
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8/-/util-utf8-3.310.0.tgz",
+			"integrity": "sha512-DnLfFT8uCO22uOJc0pt0DsSNau1GTisngBCDw8jQuWT5CqogMJu4b/uXmwEqfj8B3GX6Xsz8zOd6JpRlPftQoA==",
+			"dependencies": {
+				"@aws-sdk/util-buffer-from": "3.310.0",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/util-utf8-browser": {
+			"version": "3.259.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.259.0.tgz",
+			"integrity": "sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==",
+			"dependencies": {
+				"tslib": "^2.3.1"
+			}
+		},
+		"node_modules/@aws-sdk/util-utf8-browser/node_modules/tslib": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+			"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+		},
+		"node_modules/@aws-sdk/util-utf8/node_modules/tslib": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+			"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+		},
+		"node_modules/@aws-sdk/util-waiter": {
+			"version": "3.338.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.338.0.tgz",
+			"integrity": "sha512-15yWYJo/M4VDpZjlXgQDM4Du8UjX33eIVPJDrOmn/u+UrD6QUXoBuLXKns0uAMUTPFacBGZ0NwMywxieq0g11Q==",
+			"dependencies": {
+				"@aws-sdk/abort-controller": "3.338.0",
+				"@aws-sdk/types": "3.338.0",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/util-waiter/node_modules/tslib": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+			"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
 		},
 		"node_modules/@babel/code-frame": {
 			"version": "7.21.4",
@@ -1659,6 +3001,39 @@
 				"@sinonjs/commons": "^3.0.0"
 			}
 		},
+		"node_modules/@smithy/protocol-http": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-1.0.1.tgz",
+			"integrity": "sha512-9OrEn0WfOVtBNYJUjUAn9AOiJ4lzERCJJ/JeZs8E6yajTGxBaFRxUnNBHiNqoDJVg076hY36UmEnPx7xXrvUSg==",
+			"dependencies": {
+				"@smithy/types": "^1.0.0",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/protocol-http/node_modules/tslib": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+			"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+		},
+		"node_modules/@smithy/types": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.0.0.tgz",
+			"integrity": "sha512-kc1m5wPBHQCTixwuaOh9vnak/iJm21DrSf9UK6yDE5S3mQQ4u11pqAUiKWnlrZnYkeLfAI9UEHj9OaMT1v5Umg==",
+			"dependencies": {
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/types/node_modules/tslib": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+			"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+		},
 		"node_modules/@szmarczak/http-timer": {
 			"version": "4.0.6",
 			"resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
@@ -2886,6 +4261,11 @@
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
 			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
 		},
+		"node_modules/bowser": {
+			"version": "2.11.0",
+			"resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
+			"integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
+		},
 		"node_modules/brace-expansion": {
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -3147,6 +4527,16 @@
 					"url": "https://github.com/sponsors/ai"
 				}
 			]
+		},
+		"node_modules/celebrate": {
+			"version": "15.0.1",
+			"resolved": "https://registry.npmjs.org/celebrate/-/celebrate-15.0.1.tgz",
+			"integrity": "sha512-K2y221k10u+K2t9w25802qXh8h1mVWZf+6pl7zHdlhhwzrOSQFnnw+GsR8k17oyn4Y3fVErBGsO/+CeW8N7aRQ==",
+			"dependencies": {
+				"escape-html": "1.0.3",
+				"joi": "17.x.x",
+				"lodash": "4.17.x"
+			}
 		},
 		"node_modules/chalk": {
 			"version": "4.1.2",
@@ -4802,6 +6192,21 @@
 			"resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
 			"integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
 			"dev": true
+		},
+		"node_modules/fast-xml-parser": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.1.2.tgz",
+			"integrity": "sha512-CDYeykkle1LiA/uqQyNwYpFbyF6Axec6YapmpUP+/RHWIoR1zKjocdvNaTsxCxZzQ6v9MLXaSYm9Qq0thv0DHg==",
+			"dependencies": {
+				"strnum": "^1.0.5"
+			},
+			"bin": {
+				"fxparser": "src/cli/cli.js"
+			},
+			"funding": {
+				"type": "paypal",
+				"url": "https://paypal.me/naturalintelligence"
+			}
 		},
 		"node_modules/fastest-levenshtein": {
 			"version": "1.0.16",
@@ -7017,8 +8422,7 @@
 		"node_modules/lodash": {
 			"version": "4.17.21",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-			"dev": true
+			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
 		},
 		"node_modules/lodash.clonedeep": {
 			"version": "4.5.0",
@@ -9374,6 +10778,11 @@
 				"node": ">=0.8.0"
 			}
 		},
+		"node_modules/strnum": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
+			"integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
+		},
 		"node_modules/strtok3": {
 			"version": "6.3.0",
 			"resolved": "https://registry.npmjs.org/strtok3/-/strtok3-6.3.0.tgz",
@@ -9845,8 +11254,7 @@
 		"node_modules/tslib": {
 			"version": "1.14.1",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-			"dev": true
+			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
 		},
 		"node_modules/tsutils": {
 			"version": "3.21.0",
@@ -10562,6 +11970,1290 @@
 				"@jsdevtools/ono": "^7.1.3",
 				"call-me-maybe": "^1.0.1",
 				"z-schema": "^5.0.1"
+			}
+		},
+		"@aws-crypto/crc32": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-3.0.0.tgz",
+			"integrity": "sha512-IzSgsrxUcsrejQbPVilIKy16kAT52EwB6zSaI+M3xxIhKh5+aldEyvI+z6erM7TCLB2BJsFrtHjp6/4/sr+3dA==",
+			"requires": {
+				"@aws-crypto/util": "^3.0.0",
+				"@aws-sdk/types": "^3.222.0",
+				"tslib": "^1.11.1"
+			}
+		},
+		"@aws-crypto/ie11-detection": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
+			"integrity": "sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==",
+			"requires": {
+				"tslib": "^1.11.1"
+			}
+		},
+		"@aws-crypto/sha256-browser": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz",
+			"integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
+			"requires": {
+				"@aws-crypto/ie11-detection": "^3.0.0",
+				"@aws-crypto/sha256-js": "^3.0.0",
+				"@aws-crypto/supports-web-crypto": "^3.0.0",
+				"@aws-crypto/util": "^3.0.0",
+				"@aws-sdk/types": "^3.222.0",
+				"@aws-sdk/util-locate-window": "^3.0.0",
+				"@aws-sdk/util-utf8-browser": "^3.0.0",
+				"tslib": "^1.11.1"
+			}
+		},
+		"@aws-crypto/sha256-js": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
+			"integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
+			"requires": {
+				"@aws-crypto/util": "^3.0.0",
+				"@aws-sdk/types": "^3.222.0",
+				"tslib": "^1.11.1"
+			}
+		},
+		"@aws-crypto/supports-web-crypto": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz",
+			"integrity": "sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==",
+			"requires": {
+				"tslib": "^1.11.1"
+			}
+		},
+		"@aws-crypto/util": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
+			"integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
+			"requires": {
+				"@aws-sdk/types": "^3.222.0",
+				"@aws-sdk/util-utf8-browser": "^3.0.0",
+				"tslib": "^1.11.1"
+			}
+		},
+		"@aws-sdk/abort-controller": {
+			"version": "3.338.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.338.0.tgz",
+			"integrity": "sha512-/yLI32+HwFNBRJ39jMXw+/cn3AnlCuJpQd7Ax4887g32Dgte5eyrfY8sJUOL6902BUmAq4oSRI5QeBXNplO0Xw==",
+			"requires": {
+				"@aws-sdk/types": "3.338.0",
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.5.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+					"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+				}
+			}
+		},
+		"@aws-sdk/client-lambda": {
+			"version": "3.338.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-lambda/-/client-lambda-3.338.0.tgz",
+			"integrity": "sha512-Xq/9c7d4y4wG9SQyAKzw8bSc2q7B2rYiZqFmOocrqU3J8poH/yYpAxps/lWurlF7LJ3d09SMw2rzZR9eMckGbw==",
+			"requires": {
+				"@aws-crypto/sha256-browser": "3.0.0",
+				"@aws-crypto/sha256-js": "3.0.0",
+				"@aws-sdk/client-sts": "3.338.0",
+				"@aws-sdk/config-resolver": "3.338.0",
+				"@aws-sdk/credential-provider-node": "3.338.0",
+				"@aws-sdk/eventstream-serde-browser": "3.338.0",
+				"@aws-sdk/eventstream-serde-config-resolver": "3.338.0",
+				"@aws-sdk/eventstream-serde-node": "3.338.0",
+				"@aws-sdk/fetch-http-handler": "3.338.0",
+				"@aws-sdk/hash-node": "3.338.0",
+				"@aws-sdk/invalid-dependency": "3.338.0",
+				"@aws-sdk/middleware-content-length": "3.338.0",
+				"@aws-sdk/middleware-endpoint": "3.338.0",
+				"@aws-sdk/middleware-host-header": "3.338.0",
+				"@aws-sdk/middleware-logger": "3.338.0",
+				"@aws-sdk/middleware-recursion-detection": "3.338.0",
+				"@aws-sdk/middleware-retry": "3.338.0",
+				"@aws-sdk/middleware-serde": "3.338.0",
+				"@aws-sdk/middleware-signing": "3.338.0",
+				"@aws-sdk/middleware-stack": "3.338.0",
+				"@aws-sdk/middleware-user-agent": "3.338.0",
+				"@aws-sdk/node-config-provider": "3.338.0",
+				"@aws-sdk/node-http-handler": "3.338.0",
+				"@aws-sdk/smithy-client": "3.338.0",
+				"@aws-sdk/types": "3.338.0",
+				"@aws-sdk/url-parser": "3.338.0",
+				"@aws-sdk/util-base64": "3.310.0",
+				"@aws-sdk/util-body-length-browser": "3.310.0",
+				"@aws-sdk/util-body-length-node": "3.310.0",
+				"@aws-sdk/util-defaults-mode-browser": "3.338.0",
+				"@aws-sdk/util-defaults-mode-node": "3.338.0",
+				"@aws-sdk/util-endpoints": "3.338.0",
+				"@aws-sdk/util-retry": "3.338.0",
+				"@aws-sdk/util-user-agent-browser": "3.338.0",
+				"@aws-sdk/util-user-agent-node": "3.338.0",
+				"@aws-sdk/util-utf8": "3.310.0",
+				"@aws-sdk/util-waiter": "3.338.0",
+				"@smithy/protocol-http": "^1.0.1",
+				"@smithy/types": "^1.0.0",
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.5.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+					"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+				}
+			}
+		},
+		"@aws-sdk/client-sso": {
+			"version": "3.338.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.338.0.tgz",
+			"integrity": "sha512-EglKsGlVph65PuFPKq1nGlxsY99XM2xHJaB1uX0bQEC94qrmS/M4a5kno5tiUnTWO1K+K4JBQiOxdGJs0GUS+w==",
+			"requires": {
+				"@aws-crypto/sha256-browser": "3.0.0",
+				"@aws-crypto/sha256-js": "3.0.0",
+				"@aws-sdk/config-resolver": "3.338.0",
+				"@aws-sdk/fetch-http-handler": "3.338.0",
+				"@aws-sdk/hash-node": "3.338.0",
+				"@aws-sdk/invalid-dependency": "3.338.0",
+				"@aws-sdk/middleware-content-length": "3.338.0",
+				"@aws-sdk/middleware-endpoint": "3.338.0",
+				"@aws-sdk/middleware-host-header": "3.338.0",
+				"@aws-sdk/middleware-logger": "3.338.0",
+				"@aws-sdk/middleware-recursion-detection": "3.338.0",
+				"@aws-sdk/middleware-retry": "3.338.0",
+				"@aws-sdk/middleware-serde": "3.338.0",
+				"@aws-sdk/middleware-stack": "3.338.0",
+				"@aws-sdk/middleware-user-agent": "3.338.0",
+				"@aws-sdk/node-config-provider": "3.338.0",
+				"@aws-sdk/node-http-handler": "3.338.0",
+				"@aws-sdk/smithy-client": "3.338.0",
+				"@aws-sdk/types": "3.338.0",
+				"@aws-sdk/url-parser": "3.338.0",
+				"@aws-sdk/util-base64": "3.310.0",
+				"@aws-sdk/util-body-length-browser": "3.310.0",
+				"@aws-sdk/util-body-length-node": "3.310.0",
+				"@aws-sdk/util-defaults-mode-browser": "3.338.0",
+				"@aws-sdk/util-defaults-mode-node": "3.338.0",
+				"@aws-sdk/util-endpoints": "3.338.0",
+				"@aws-sdk/util-retry": "3.338.0",
+				"@aws-sdk/util-user-agent-browser": "3.338.0",
+				"@aws-sdk/util-user-agent-node": "3.338.0",
+				"@aws-sdk/util-utf8": "3.310.0",
+				"@smithy/protocol-http": "^1.0.1",
+				"@smithy/types": "^1.0.0",
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.5.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+					"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+				}
+			}
+		},
+		"@aws-sdk/client-sso-oidc": {
+			"version": "3.338.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.338.0.tgz",
+			"integrity": "sha512-mny5Q3LWKTcMMFS8WxeOCTinl193z7vS3b+eQz09K4jb1Lq04Bpjw25cySgBnhMGZ7QHQiYBscNLyu/TfOKiHA==",
+			"requires": {
+				"@aws-crypto/sha256-browser": "3.0.0",
+				"@aws-crypto/sha256-js": "3.0.0",
+				"@aws-sdk/config-resolver": "3.338.0",
+				"@aws-sdk/fetch-http-handler": "3.338.0",
+				"@aws-sdk/hash-node": "3.338.0",
+				"@aws-sdk/invalid-dependency": "3.338.0",
+				"@aws-sdk/middleware-content-length": "3.338.0",
+				"@aws-sdk/middleware-endpoint": "3.338.0",
+				"@aws-sdk/middleware-host-header": "3.338.0",
+				"@aws-sdk/middleware-logger": "3.338.0",
+				"@aws-sdk/middleware-recursion-detection": "3.338.0",
+				"@aws-sdk/middleware-retry": "3.338.0",
+				"@aws-sdk/middleware-serde": "3.338.0",
+				"@aws-sdk/middleware-stack": "3.338.0",
+				"@aws-sdk/middleware-user-agent": "3.338.0",
+				"@aws-sdk/node-config-provider": "3.338.0",
+				"@aws-sdk/node-http-handler": "3.338.0",
+				"@aws-sdk/smithy-client": "3.338.0",
+				"@aws-sdk/types": "3.338.0",
+				"@aws-sdk/url-parser": "3.338.0",
+				"@aws-sdk/util-base64": "3.310.0",
+				"@aws-sdk/util-body-length-browser": "3.310.0",
+				"@aws-sdk/util-body-length-node": "3.310.0",
+				"@aws-sdk/util-defaults-mode-browser": "3.338.0",
+				"@aws-sdk/util-defaults-mode-node": "3.338.0",
+				"@aws-sdk/util-endpoints": "3.338.0",
+				"@aws-sdk/util-retry": "3.338.0",
+				"@aws-sdk/util-user-agent-browser": "3.338.0",
+				"@aws-sdk/util-user-agent-node": "3.338.0",
+				"@aws-sdk/util-utf8": "3.310.0",
+				"@smithy/protocol-http": "^1.0.1",
+				"@smithy/types": "^1.0.0",
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.5.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+					"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+				}
+			}
+		},
+		"@aws-sdk/client-sts": {
+			"version": "3.338.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.338.0.tgz",
+			"integrity": "sha512-FBHy/G7BAPX0CdEeeGYpoAnKXVCSIIkESLU2wF6x880z+U2IqiL48Fzoa5qoLaLPQaK/30P7ytznkqm4vd1OFw==",
+			"requires": {
+				"@aws-crypto/sha256-browser": "3.0.0",
+				"@aws-crypto/sha256-js": "3.0.0",
+				"@aws-sdk/config-resolver": "3.338.0",
+				"@aws-sdk/credential-provider-node": "3.338.0",
+				"@aws-sdk/fetch-http-handler": "3.338.0",
+				"@aws-sdk/hash-node": "3.338.0",
+				"@aws-sdk/invalid-dependency": "3.338.0",
+				"@aws-sdk/middleware-content-length": "3.338.0",
+				"@aws-sdk/middleware-endpoint": "3.338.0",
+				"@aws-sdk/middleware-host-header": "3.338.0",
+				"@aws-sdk/middleware-logger": "3.338.0",
+				"@aws-sdk/middleware-recursion-detection": "3.338.0",
+				"@aws-sdk/middleware-retry": "3.338.0",
+				"@aws-sdk/middleware-sdk-sts": "3.338.0",
+				"@aws-sdk/middleware-serde": "3.338.0",
+				"@aws-sdk/middleware-signing": "3.338.0",
+				"@aws-sdk/middleware-stack": "3.338.0",
+				"@aws-sdk/middleware-user-agent": "3.338.0",
+				"@aws-sdk/node-config-provider": "3.338.0",
+				"@aws-sdk/node-http-handler": "3.338.0",
+				"@aws-sdk/smithy-client": "3.338.0",
+				"@aws-sdk/types": "3.338.0",
+				"@aws-sdk/url-parser": "3.338.0",
+				"@aws-sdk/util-base64": "3.310.0",
+				"@aws-sdk/util-body-length-browser": "3.310.0",
+				"@aws-sdk/util-body-length-node": "3.310.0",
+				"@aws-sdk/util-defaults-mode-browser": "3.338.0",
+				"@aws-sdk/util-defaults-mode-node": "3.338.0",
+				"@aws-sdk/util-endpoints": "3.338.0",
+				"@aws-sdk/util-retry": "3.338.0",
+				"@aws-sdk/util-user-agent-browser": "3.338.0",
+				"@aws-sdk/util-user-agent-node": "3.338.0",
+				"@aws-sdk/util-utf8": "3.310.0",
+				"@smithy/protocol-http": "^1.0.1",
+				"@smithy/types": "^1.0.0",
+				"fast-xml-parser": "4.1.2",
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.5.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+					"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+				}
+			}
+		},
+		"@aws-sdk/config-resolver": {
+			"version": "3.338.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.338.0.tgz",
+			"integrity": "sha512-rB9WUaMfTB74Hd2mOiyPFR7Q1viT+w6SaDSR9SA1P8EeIg5H13FNdIKb736Z8/6QJhDj7whdyk1CTGV+DmXOOg==",
+			"requires": {
+				"@aws-sdk/types": "3.338.0",
+				"@aws-sdk/util-config-provider": "3.310.0",
+				"@aws-sdk/util-middleware": "3.338.0",
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.5.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+					"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+				}
+			}
+		},
+		"@aws-sdk/credential-provider-env": {
+			"version": "3.338.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.338.0.tgz",
+			"integrity": "sha512-j14vApy80tpk87C3x3uBf1caQsuR8RdQ8iOW830H/AOhsa88XaZIB/NQSX7exaIKZa2RU0Vv2wIlGAA8ko7J6g==",
+			"requires": {
+				"@aws-sdk/property-provider": "3.338.0",
+				"@aws-sdk/types": "3.338.0",
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.5.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+					"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+				}
+			}
+		},
+		"@aws-sdk/credential-provider-imds": {
+			"version": "3.338.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.338.0.tgz",
+			"integrity": "sha512-qsqeywYfJevg5pgUUUBmm7pK1bckVrl091PZB2IliFdQVnDvI5GFLf4B0oZqjaLAzPG1gVtxRvqIve+tnP/+xA==",
+			"requires": {
+				"@aws-sdk/node-config-provider": "3.338.0",
+				"@aws-sdk/property-provider": "3.338.0",
+				"@aws-sdk/types": "3.338.0",
+				"@aws-sdk/url-parser": "3.338.0",
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.5.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+					"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+				}
+			}
+		},
+		"@aws-sdk/credential-provider-ini": {
+			"version": "3.338.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.338.0.tgz",
+			"integrity": "sha512-UhgYgymT9sJiRm0peqP5EvtR4dXiS2Q2AuFgDUjBvDz8JaZlqafsIS4cfyGwTHV/xY6cdiMu5rCTe8hTyXsukQ==",
+			"requires": {
+				"@aws-sdk/credential-provider-env": "3.338.0",
+				"@aws-sdk/credential-provider-imds": "3.338.0",
+				"@aws-sdk/credential-provider-process": "3.338.0",
+				"@aws-sdk/credential-provider-sso": "3.338.0",
+				"@aws-sdk/credential-provider-web-identity": "3.338.0",
+				"@aws-sdk/property-provider": "3.338.0",
+				"@aws-sdk/shared-ini-file-loader": "3.338.0",
+				"@aws-sdk/types": "3.338.0",
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.5.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+					"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+				}
+			}
+		},
+		"@aws-sdk/credential-provider-node": {
+			"version": "3.338.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.338.0.tgz",
+			"integrity": "sha512-nZjaMRxJqX0EXMV9LA5IbRQI1pDGGZiPYX2KDfZ1Y9Gc1Y/vIZhHKOHGb1uKMAonlR076CsXlev4/tjC8SGGuw==",
+			"requires": {
+				"@aws-sdk/credential-provider-env": "3.338.0",
+				"@aws-sdk/credential-provider-imds": "3.338.0",
+				"@aws-sdk/credential-provider-ini": "3.338.0",
+				"@aws-sdk/credential-provider-process": "3.338.0",
+				"@aws-sdk/credential-provider-sso": "3.338.0",
+				"@aws-sdk/credential-provider-web-identity": "3.338.0",
+				"@aws-sdk/property-provider": "3.338.0",
+				"@aws-sdk/shared-ini-file-loader": "3.338.0",
+				"@aws-sdk/types": "3.338.0",
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.5.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+					"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+				}
+			}
+		},
+		"@aws-sdk/credential-provider-process": {
+			"version": "3.338.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.338.0.tgz",
+			"integrity": "sha512-5I1EgJxFFEg8xel2kInMpkdBKajUut0hR2fBajqCmK7Pflu8s0I2NKDots9a3YJagNrFJq38+EzoDcUvRrd2dg==",
+			"requires": {
+				"@aws-sdk/property-provider": "3.338.0",
+				"@aws-sdk/shared-ini-file-loader": "3.338.0",
+				"@aws-sdk/types": "3.338.0",
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.5.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+					"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+				}
+			}
+		},
+		"@aws-sdk/credential-provider-sso": {
+			"version": "3.338.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.338.0.tgz",
+			"integrity": "sha512-fpzYHK17iF/uFkrm4cLg/utDVKSBTWNjAiNlE3GF6CaixBCwc0QBLKHk2nG4d1ZZeMVCbIUMS7eoqfR0LYc/yw==",
+			"requires": {
+				"@aws-sdk/client-sso": "3.338.0",
+				"@aws-sdk/property-provider": "3.338.0",
+				"@aws-sdk/shared-ini-file-loader": "3.338.0",
+				"@aws-sdk/token-providers": "3.338.0",
+				"@aws-sdk/types": "3.338.0",
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.5.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+					"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+				}
+			}
+		},
+		"@aws-sdk/credential-provider-web-identity": {
+			"version": "3.338.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.338.0.tgz",
+			"integrity": "sha512-kjT/P18jM1icwjYwr8wfY//T8lv2s81ms7OC7vgiSqckmQOxpVkdsep9d44ymSUXwopmotFP7M9gGnEHS6HwAA==",
+			"requires": {
+				"@aws-sdk/property-provider": "3.338.0",
+				"@aws-sdk/types": "3.338.0",
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.5.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+					"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+				}
+			}
+		},
+		"@aws-sdk/eventstream-codec": {
+			"version": "3.338.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-codec/-/eventstream-codec-3.338.0.tgz",
+			"integrity": "sha512-D9nxnkuY6ArIr+b2Gfc0YExWgNbzgfLIljgcBawL9P4vkkE0uZgPM0fF0Paug2DpkuSluHS6PCLaM/nLbBiLAQ==",
+			"requires": {
+				"@aws-crypto/crc32": "3.0.0",
+				"@aws-sdk/types": "3.338.0",
+				"@aws-sdk/util-hex-encoding": "3.310.0",
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.5.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+					"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+				}
+			}
+		},
+		"@aws-sdk/eventstream-serde-browser": {
+			"version": "3.338.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-browser/-/eventstream-serde-browser-3.338.0.tgz",
+			"integrity": "sha512-SRaFPJpCPOghZ9vuStSBzwvVqEX0DSVQl4j1vq/9mHUj1a4Xn0qH29eLBxsyB5NOQNb46RMdd8UTNgNSnCI74w==",
+			"requires": {
+				"@aws-sdk/eventstream-serde-universal": "3.338.0",
+				"@aws-sdk/types": "3.338.0",
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.5.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+					"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+				}
+			}
+		},
+		"@aws-sdk/eventstream-serde-config-resolver": {
+			"version": "3.338.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.338.0.tgz",
+			"integrity": "sha512-utid/nDd6IoPXWwz/mCnAwWWNgntK53feRLsztyWg7GHJabXli/kXo6U/3+Mn7Q2RS4eAASpqhYXXrVni5SgTA==",
+			"requires": {
+				"@aws-sdk/types": "3.338.0",
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.5.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+					"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+				}
+			}
+		},
+		"@aws-sdk/eventstream-serde-node": {
+			"version": "3.338.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-node/-/eventstream-serde-node-3.338.0.tgz",
+			"integrity": "sha512-Fwnrgaa6rs/0HMD3NVk1FcxZqgtG5xZz9qIlSLt5JFIG/rpBTrMREi+KIhLHvd3/4ZhkdLjX7y+ml8K6atSveA==",
+			"requires": {
+				"@aws-sdk/eventstream-serde-universal": "3.338.0",
+				"@aws-sdk/types": "3.338.0",
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.5.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+					"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+				}
+			}
+		},
+		"@aws-sdk/eventstream-serde-universal": {
+			"version": "3.338.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-universal/-/eventstream-serde-universal-3.338.0.tgz",
+			"integrity": "sha512-uuHu1nksdPPevuSUkq5aOo7j1Zb6IRSuQ0fV0zuolg2i1B2wAQjrkWH9EcvGzOe0/yWEQF3ohggczuovn4yCzQ==",
+			"requires": {
+				"@aws-sdk/eventstream-codec": "3.338.0",
+				"@aws-sdk/types": "3.338.0",
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.5.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+					"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+				}
+			}
+		},
+		"@aws-sdk/fetch-http-handler": {
+			"version": "3.338.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.338.0.tgz",
+			"integrity": "sha512-NOIQmeSa51J2nFAzl99IjxwQkq27cdNJzF59jQWzpUCGbxXfMD4WWy2NHubabSFuJ4FJU2eyoQHUNUFc6/uxXA==",
+			"requires": {
+				"@aws-sdk/protocol-http": "3.338.0",
+				"@aws-sdk/querystring-builder": "3.338.0",
+				"@aws-sdk/types": "3.338.0",
+				"@aws-sdk/util-base64": "3.310.0",
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.5.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+					"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+				}
+			}
+		},
+		"@aws-sdk/hash-node": {
+			"version": "3.338.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.338.0.tgz",
+			"integrity": "sha512-udveX3ZRO1oUbyBTQH0LJ8Ika7uk0pHuXrqapdi66GGRJB50IhmOg372zUEwZjDB7DZYXfGTCuAj2OoEalgpBA==",
+			"requires": {
+				"@aws-sdk/types": "3.338.0",
+				"@aws-sdk/util-buffer-from": "3.310.0",
+				"@aws-sdk/util-utf8": "3.310.0",
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.5.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+					"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+				}
+			}
+		},
+		"@aws-sdk/invalid-dependency": {
+			"version": "3.338.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.338.0.tgz",
+			"integrity": "sha512-m6r1fTTGSl0V6l8Z+Ii4Ei8VFpDmu0AT6A59ZhJaMZgxf925ywuCPydyDW9ZqTLE0e7CgxhEHEsH1+HzpVuHTw==",
+			"requires": {
+				"@aws-sdk/types": "3.338.0",
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.5.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+					"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+				}
+			}
+		},
+		"@aws-sdk/is-array-buffer": {
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.310.0.tgz",
+			"integrity": "sha512-urnbcCR+h9NWUnmOtet/s4ghvzsidFmspfhYaHAmSRdy9yDjdjBJMFjjsn85A1ODUktztm+cVncXjQ38WCMjMQ==",
+			"requires": {
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.5.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+					"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+				}
+			}
+		},
+		"@aws-sdk/middleware-content-length": {
+			"version": "3.338.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.338.0.tgz",
+			"integrity": "sha512-m2C+yJaNmbA3ocBp/7ImUUuimymV5JsFdV7yAibpbYMX22g3q83nieOF9x0I66J0+h+/bcriz/T1ZJAPANLz/g==",
+			"requires": {
+				"@aws-sdk/protocol-http": "3.338.0",
+				"@aws-sdk/types": "3.338.0",
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.5.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+					"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+				}
+			}
+		},
+		"@aws-sdk/middleware-endpoint": {
+			"version": "3.338.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.338.0.tgz",
+			"integrity": "sha512-bzL9Q8lFidg2NTjGVGDKI6yPG/XiPS+VIAMHJeihQmcv1alIy+N3IL4bEN15Fg+cwaGm+P3BevcLIHmcCOVb4w==",
+			"requires": {
+				"@aws-sdk/middleware-serde": "3.338.0",
+				"@aws-sdk/types": "3.338.0",
+				"@aws-sdk/url-parser": "3.338.0",
+				"@aws-sdk/util-middleware": "3.338.0",
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.5.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+					"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+				}
+			}
+		},
+		"@aws-sdk/middleware-host-header": {
+			"version": "3.338.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.338.0.tgz",
+			"integrity": "sha512-k3C7oppkrqeKrAJt9XIl45SdELtnph9BF0QypjyRfT5MNEDnMMsQkc6xy3ZMqG5dWQq6B2l8C+JL7pOvkSQP3w==",
+			"requires": {
+				"@aws-sdk/protocol-http": "3.338.0",
+				"@aws-sdk/types": "3.338.0",
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.5.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+					"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+				}
+			}
+		},
+		"@aws-sdk/middleware-logger": {
+			"version": "3.338.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.338.0.tgz",
+			"integrity": "sha512-btj9U0Xovq/UAu3Ur4lAfF7Q3DvvwJ/0UUWsI6GgSzzqSOFgKCz7hCP2GZIT8aXEA5hJOpBOEMkNMjWPNa91Hg==",
+			"requires": {
+				"@aws-sdk/types": "3.338.0",
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.5.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+					"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+				}
+			}
+		},
+		"@aws-sdk/middleware-recursion-detection": {
+			"version": "3.338.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.338.0.tgz",
+			"integrity": "sha512-fu5KwiHHSqC8KTQH6xdJ9+dua4gQcXSFLE5fVsergqd0uVdsmhiI+IDfW6QNwF/lmCqnoKDkpeasuB98eG2tow==",
+			"requires": {
+				"@aws-sdk/protocol-http": "3.338.0",
+				"@aws-sdk/types": "3.338.0",
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.5.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+					"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+				}
+			}
+		},
+		"@aws-sdk/middleware-retry": {
+			"version": "3.338.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.338.0.tgz",
+			"integrity": "sha512-nw1oPFkB7TdDG4Vlz2Td47ft/2Gmx1bA18QfE9K1mMWZ4nnoAL8xnHbowlTfHo62+BbFCAPu53PzDUCncBL0iw==",
+			"requires": {
+				"@aws-sdk/protocol-http": "3.338.0",
+				"@aws-sdk/service-error-classification": "3.338.0",
+				"@aws-sdk/types": "3.338.0",
+				"@aws-sdk/util-middleware": "3.338.0",
+				"@aws-sdk/util-retry": "3.338.0",
+				"tslib": "^2.5.0",
+				"uuid": "^8.3.2"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.5.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+					"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+				},
+				"uuid": {
+					"version": "8.3.2",
+					"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+					"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+				}
+			}
+		},
+		"@aws-sdk/middleware-sdk-sts": {
+			"version": "3.338.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.338.0.tgz",
+			"integrity": "sha512-aZ8eFVaot8oYQri1wOesrA3gLizeAHtlA/ELlqxoGDJtO011J4/hTHTn0iJGbktaCvc1L3TF6mgOsgXpudYqMg==",
+			"requires": {
+				"@aws-sdk/middleware-signing": "3.338.0",
+				"@aws-sdk/types": "3.338.0",
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.5.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+					"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+				}
+			}
+		},
+		"@aws-sdk/middleware-serde": {
+			"version": "3.338.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.338.0.tgz",
+			"integrity": "sha512-AabRLrE6sk9tqQlQ7z3kn4gTHNN7Anjk/AM0ZEu96WcWjedcpgM1vVpKTBE7vjnxcTRNq0CEM3GLtQqaZ7/HjQ==",
+			"requires": {
+				"@aws-sdk/types": "3.338.0",
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.5.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+					"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+				}
+			}
+		},
+		"@aws-sdk/middleware-signing": {
+			"version": "3.338.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.338.0.tgz",
+			"integrity": "sha512-AprhhShMF75mOx80SABujLwrU/w2uHQIvWd6aF3BsE5JRI3uQZRqspfjFCaK52HNLQPj3sCQUw1GeiZJ8GyWCw==",
+			"requires": {
+				"@aws-sdk/property-provider": "3.338.0",
+				"@aws-sdk/protocol-http": "3.338.0",
+				"@aws-sdk/signature-v4": "3.338.0",
+				"@aws-sdk/types": "3.338.0",
+				"@aws-sdk/util-middleware": "3.338.0",
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.5.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+					"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+				}
+			}
+		},
+		"@aws-sdk/middleware-stack": {
+			"version": "3.338.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.338.0.tgz",
+			"integrity": "sha512-9zXyiklX9AK9ZIXuIPzWzz2vevBEcnBs9UNIxiHl4NBZ8d8oyTvaES1PtFuwL6f7ANSZ9EGVQ2rdTTnMNxMI1A==",
+			"requires": {
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.5.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+					"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+				}
+			}
+		},
+		"@aws-sdk/middleware-user-agent": {
+			"version": "3.338.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.338.0.tgz",
+			"integrity": "sha512-DMqODOsDMFMPcDw2Ya6a0i34AhaBDRpp3vJ+FK3zPxUIsv6iHA+XqEcXLOxROLLoydoyxus7k2U+EWibLZrFbQ==",
+			"requires": {
+				"@aws-sdk/protocol-http": "3.338.0",
+				"@aws-sdk/types": "3.338.0",
+				"@aws-sdk/util-endpoints": "3.338.0",
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.5.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+					"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+				}
+			}
+		},
+		"@aws-sdk/node-config-provider": {
+			"version": "3.338.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.338.0.tgz",
+			"integrity": "sha512-YO7yWg3ipnUI5u6D+Zn2NUpjj5krwc8zNWeY79ULVIp9g7faqGX3xMSjeRSrpZ83s5jg1dOm/+bB0gw7mCrRCw==",
+			"requires": {
+				"@aws-sdk/property-provider": "3.338.0",
+				"@aws-sdk/shared-ini-file-loader": "3.338.0",
+				"@aws-sdk/types": "3.338.0",
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.5.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+					"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+				}
+			}
+		},
+		"@aws-sdk/node-http-handler": {
+			"version": "3.338.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.338.0.tgz",
+			"integrity": "sha512-V1BLzCruiv45tJ0vXjiamY8LncIsUFsXYJGDupomFYhWRN8L1MUB9f2vdKn5X3wXn/yKrluwTmNaryrIqd9akA==",
+			"requires": {
+				"@aws-sdk/abort-controller": "3.338.0",
+				"@aws-sdk/protocol-http": "3.338.0",
+				"@aws-sdk/querystring-builder": "3.338.0",
+				"@aws-sdk/types": "3.338.0",
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.5.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+					"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+				}
+			}
+		},
+		"@aws-sdk/property-provider": {
+			"version": "3.338.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.338.0.tgz",
+			"integrity": "sha512-mC+ZJ738ipif6ZkH59gcipozYj1FOfpXr9pGVCA2hJGLDdaBwI2Jfpb2qCqbsTNtoCjBuIy+sQHGmUHyclgYHg==",
+			"requires": {
+				"@aws-sdk/types": "3.338.0",
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.5.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+					"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+				}
+			}
+		},
+		"@aws-sdk/protocol-http": {
+			"version": "3.338.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.338.0.tgz",
+			"integrity": "sha512-JX03Q2gshdzOWtA/07kdpk0hqeOrOfwuF8TB97g66VCcIopYQkCeNH1zzkWu+RsGxfSlzQ7up+ZM6sclYXyB1A==",
+			"requires": {
+				"@aws-sdk/types": "3.338.0",
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.5.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+					"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+				}
+			}
+		},
+		"@aws-sdk/querystring-builder": {
+			"version": "3.338.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.338.0.tgz",
+			"integrity": "sha512-IB3YhO93Htwt2SxJx4VWsN57Rt1KEsvZ6PbneO4bcS96E04BlfBujYMZ+QxEM3EJxorhpkwbI2QnI12IjD8FhA==",
+			"requires": {
+				"@aws-sdk/types": "3.338.0",
+				"@aws-sdk/util-uri-escape": "3.310.0",
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.5.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+					"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+				}
+			}
+		},
+		"@aws-sdk/querystring-parser": {
+			"version": "3.338.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.338.0.tgz",
+			"integrity": "sha512-vtI8Gqx4yj0BZlWonRMgLz68sHt5H48HN+ClnY+fDDB/8KLnCuwZ3TGKmYIbYbshL9wjJz0A9aLzuC6nPQ5JKw==",
+			"requires": {
+				"@aws-sdk/types": "3.338.0",
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.5.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+					"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+				}
+			}
+		},
+		"@aws-sdk/service-error-classification": {
+			"version": "3.338.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.338.0.tgz",
+			"integrity": "sha512-BJFr2mx/N3NbycGTlMMGRBc0tGcHXHEbMPy1H2RbejzL23zh27MchaL1WAK9SvwVMKS29hSDbhkuVR2ABRjerA=="
+		},
+		"@aws-sdk/shared-ini-file-loader": {
+			"version": "3.338.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.338.0.tgz",
+			"integrity": "sha512-MA1Sp97LFlOXcUaXgo47j86IsPRWYq1V/JqR+uu0zofZw4Xlt7Y6F+mmnDHvuuMy6R2ltzjXSwgrrW3k0bxFPA==",
+			"requires": {
+				"@aws-sdk/types": "3.338.0",
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.5.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+					"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+				}
+			}
+		},
+		"@aws-sdk/signature-v4": {
+			"version": "3.338.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.338.0.tgz",
+			"integrity": "sha512-EwKTe/8Iwab/v0eo27w7DRYlqp9wEZEhuRfOMwTikUVH6iuTnW6AXjcIUfcRYBRbx2zqnRSiMAZkjN6ZFYm0bQ==",
+			"requires": {
+				"@aws-sdk/is-array-buffer": "3.310.0",
+				"@aws-sdk/types": "3.338.0",
+				"@aws-sdk/util-hex-encoding": "3.310.0",
+				"@aws-sdk/util-middleware": "3.338.0",
+				"@aws-sdk/util-uri-escape": "3.310.0",
+				"@aws-sdk/util-utf8": "3.310.0",
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.5.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+					"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+				}
+			}
+		},
+		"@aws-sdk/smithy-client": {
+			"version": "3.338.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.338.0.tgz",
+			"integrity": "sha512-IpFLdLG8GwaiFdqVXf+WyU47Hfa2BMIupAU6iSkE2ZO0lBdg+efn/BBwis5WbBNTDCaaU0xH9y68SmnqqtD7pA==",
+			"requires": {
+				"@aws-sdk/middleware-stack": "3.338.0",
+				"@aws-sdk/types": "3.338.0",
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.5.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+					"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+				}
+			}
+		},
+		"@aws-sdk/token-providers": {
+			"version": "3.338.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.338.0.tgz",
+			"integrity": "sha512-wuiEGcWiMeq5N68M489i2iGYcCad9p1btNEOFgus+JO3DRSA6HZXizLI1wqfbUm5Ei8512AvUKB6N8PMzahQsg==",
+			"requires": {
+				"@aws-sdk/client-sso-oidc": "3.338.0",
+				"@aws-sdk/property-provider": "3.338.0",
+				"@aws-sdk/shared-ini-file-loader": "3.338.0",
+				"@aws-sdk/types": "3.338.0",
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.5.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+					"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+				}
+			}
+		},
+		"@aws-sdk/types": {
+			"version": "3.338.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.338.0.tgz",
+			"integrity": "sha512-hrNK15o+EObLrl9oWOyxJN2dwjgbdBMGolLEVP/wR/+M9ojHgk/x1kMsCVcV82a8Vgdtqx1TyOC3UugUPT0+NA==",
+			"requires": {
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.5.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+					"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+				}
+			}
+		},
+		"@aws-sdk/url-parser": {
+			"version": "3.338.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.338.0.tgz",
+			"integrity": "sha512-x8a5swfZ6iWJZEA8rm99OKQ1A6xhWPP1taQUzoPavGCzPAOqyc8cd0FcXYMxvtXb3FeBhGaI8tiGKvelJro0+A==",
+			"requires": {
+				"@aws-sdk/querystring-parser": "3.338.0",
+				"@aws-sdk/types": "3.338.0",
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.5.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+					"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+				}
+			}
+		},
+		"@aws-sdk/util-base64": {
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.310.0.tgz",
+			"integrity": "sha512-v3+HBKQvqgdzcbL+pFswlx5HQsd9L6ZTlyPVL2LS9nNXnCcR3XgGz9jRskikRUuUvUXtkSG1J88GAOnJ/apTPg==",
+			"requires": {
+				"@aws-sdk/util-buffer-from": "3.310.0",
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.5.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+					"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+				}
+			}
+		},
+		"@aws-sdk/util-body-length-browser": {
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.310.0.tgz",
+			"integrity": "sha512-sxsC3lPBGfpHtNTUoGXMQXLwjmR0zVpx0rSvzTPAuoVILVsp5AU/w5FphNPxD5OVIjNbZv9KsKTuvNTiZjDp9g==",
+			"requires": {
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.5.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+					"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+				}
+			}
+		},
+		"@aws-sdk/util-body-length-node": {
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.310.0.tgz",
+			"integrity": "sha512-2tqGXdyKhyA6w4zz7UPoS8Ip+7sayOg9BwHNidiGm2ikbDxm1YrCfYXvCBdwaJxa4hJfRVz+aL9e+d3GqPI9pQ==",
+			"requires": {
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.5.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+					"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+				}
+			}
+		},
+		"@aws-sdk/util-buffer-from": {
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.310.0.tgz",
+			"integrity": "sha512-i6LVeXFtGih5Zs8enLrt+ExXY92QV25jtEnTKHsmlFqFAuL3VBeod6boeMXkN2p9lbSVVQ1sAOOYZOHYbYkntw==",
+			"requires": {
+				"@aws-sdk/is-array-buffer": "3.310.0",
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.5.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+					"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+				}
+			}
+		},
+		"@aws-sdk/util-config-provider": {
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.310.0.tgz",
+			"integrity": "sha512-xIBaYo8dwiojCw8vnUcIL4Z5tyfb1v3yjqyJKJWV/dqKUFOOS0U591plmXbM+M/QkXyML3ypon1f8+BoaDExrg==",
+			"requires": {
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.5.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+					"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+				}
+			}
+		},
+		"@aws-sdk/util-defaults-mode-browser": {
+			"version": "3.338.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.338.0.tgz",
+			"integrity": "sha512-Zfr5c7JKMJTfb7z+hgd0ioU5iw+wId6Cppc5V1HpZuS2YY4Mn3aJIixzyzhIoCzbmk/yIkf96981epM9eo3/TA==",
+			"requires": {
+				"@aws-sdk/property-provider": "3.338.0",
+				"@aws-sdk/types": "3.338.0",
+				"bowser": "^2.11.0",
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.5.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+					"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+				}
+			}
+		},
+		"@aws-sdk/util-defaults-mode-node": {
+			"version": "3.338.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.338.0.tgz",
+			"integrity": "sha512-DFM3BSpSetshZTgTjueCkAYZWS0tn5zl7SjkSpFhWQZ8Tt/Df3/DEjcPvxzmC/5vgYSUXNsqcI7lLAJk9aGZAA==",
+			"requires": {
+				"@aws-sdk/config-resolver": "3.338.0",
+				"@aws-sdk/credential-provider-imds": "3.338.0",
+				"@aws-sdk/node-config-provider": "3.338.0",
+				"@aws-sdk/property-provider": "3.338.0",
+				"@aws-sdk/types": "3.338.0",
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.5.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+					"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+				}
+			}
+		},
+		"@aws-sdk/util-endpoints": {
+			"version": "3.338.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.338.0.tgz",
+			"integrity": "sha512-0gBQcohbNcBsBR7oyaD0Dg2m6qOmfp0G1iN/NM23gwAr2H3ni8tUXfs1HsZzxikOwUr6dSLASokc30vQXBF44A==",
+			"requires": {
+				"@aws-sdk/types": "3.338.0",
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.5.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+					"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+				}
+			}
+		},
+		"@aws-sdk/util-hex-encoding": {
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.310.0.tgz",
+			"integrity": "sha512-sVN7mcCCDSJ67pI1ZMtk84SKGqyix6/0A1Ab163YKn+lFBQRMKexleZzpYzNGxYzmQS6VanP/cfU7NiLQOaSfA==",
+			"requires": {
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.5.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+					"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+				}
+			}
+		},
+		"@aws-sdk/util-locate-window": {
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.310.0.tgz",
+			"integrity": "sha512-qo2t/vBTnoXpjKxlsC2e1gBrRm80M3bId27r0BRB2VniSSe7bL1mmzM+/HFtujm0iAxtPM+aLEflLJlJeDPg0w==",
+			"requires": {
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.5.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+					"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+				}
+			}
+		},
+		"@aws-sdk/util-middleware": {
+			"version": "3.338.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.338.0.tgz",
+			"integrity": "sha512-oQuAmhi16HWEqVa+Nq4VD4Ymet9vS+uiW92reaagQrW2QFjAgJW9A6pU0PcIHF9sWY1iDKeNdV5b9odQ45PDJA==",
+			"requires": {
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.5.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+					"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+				}
+			}
+		},
+		"@aws-sdk/util-retry": {
+			"version": "3.338.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.338.0.tgz",
+			"integrity": "sha512-diR6M3gJgSgBg/87L2e8iF8urG+LOW9ZGWxhntYpYX4uhiIjwNgUPUa993553C8GIOZDHez5X9ExU4asYGQ71Q==",
+			"requires": {
+				"@aws-sdk/service-error-classification": "3.338.0",
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.5.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+					"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+				}
+			}
+		},
+		"@aws-sdk/util-uri-escape": {
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.310.0.tgz",
+			"integrity": "sha512-drzt+aB2qo2LgtDoiy/3sVG8w63cgLkqFIa2NFlGpUgHFWTXkqtbgf4L5QdjRGKWhmZsnqkbtL7vkSWEcYDJ4Q==",
+			"requires": {
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.5.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+					"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+				}
+			}
+		},
+		"@aws-sdk/util-user-agent-browser": {
+			"version": "3.338.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.338.0.tgz",
+			"integrity": "sha512-3e8D+SOtOQEtRtksOEF7EC26xPkuY6YK6biLgdtvR9JspK96rHk5eX1HEJeBJJqbxhyPaxpIw+OhWhnsrUS3hA==",
+			"requires": {
+				"@aws-sdk/types": "3.338.0",
+				"bowser": "^2.11.0",
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.5.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+					"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+				}
+			}
+		},
+		"@aws-sdk/util-user-agent-node": {
+			"version": "3.338.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.338.0.tgz",
+			"integrity": "sha512-rc+bC5KM9h25urRc+MXuViJkJ+qYG2NlCRw6xm2lSIvHFJTUjH1ZMO3mqNDYkGnQRbj0mmrVe+N77TJZGf3Q2Q==",
+			"requires": {
+				"@aws-sdk/node-config-provider": "3.338.0",
+				"@aws-sdk/types": "3.338.0",
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.5.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+					"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+				}
+			}
+		},
+		"@aws-sdk/util-utf8": {
+			"version": "3.310.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8/-/util-utf8-3.310.0.tgz",
+			"integrity": "sha512-DnLfFT8uCO22uOJc0pt0DsSNau1GTisngBCDw8jQuWT5CqogMJu4b/uXmwEqfj8B3GX6Xsz8zOd6JpRlPftQoA==",
+			"requires": {
+				"@aws-sdk/util-buffer-from": "3.310.0",
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.5.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+					"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+				}
+			}
+		},
+		"@aws-sdk/util-utf8-browser": {
+			"version": "3.259.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.259.0.tgz",
+			"integrity": "sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==",
+			"requires": {
+				"tslib": "^2.3.1"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.5.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+					"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+				}
+			}
+		},
+		"@aws-sdk/util-waiter": {
+			"version": "3.338.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.338.0.tgz",
+			"integrity": "sha512-15yWYJo/M4VDpZjlXgQDM4Du8UjX33eIVPJDrOmn/u+UrD6QUXoBuLXKns0uAMUTPFacBGZ0NwMywxieq0g11Q==",
+			"requires": {
+				"@aws-sdk/abort-controller": "3.338.0",
+				"@aws-sdk/types": "3.338.0",
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.5.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+					"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+				}
 			}
 		},
 		"@babel/code-frame": {
@@ -11819,6 +14511,37 @@
 				"@sinonjs/commons": "^3.0.0"
 			}
 		},
+		"@smithy/protocol-http": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-1.0.1.tgz",
+			"integrity": "sha512-9OrEn0WfOVtBNYJUjUAn9AOiJ4lzERCJJ/JeZs8E6yajTGxBaFRxUnNBHiNqoDJVg076hY36UmEnPx7xXrvUSg==",
+			"requires": {
+				"@smithy/types": "^1.0.0",
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.5.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+					"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+				}
+			}
+		},
+		"@smithy/types": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.0.0.tgz",
+			"integrity": "sha512-kc1m5wPBHQCTixwuaOh9vnak/iJm21DrSf9UK6yDE5S3mQQ4u11pqAUiKWnlrZnYkeLfAI9UEHj9OaMT1v5Umg==",
+			"requires": {
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.5.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+					"integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+				}
+			}
+		},
 		"@szmarczak/http-timer": {
 			"version": "4.0.6",
 			"resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
@@ -12798,6 +15521,11 @@
 				}
 			}
 		},
+		"bowser": {
+			"version": "2.11.0",
+			"resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
+			"integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
+		},
 		"brace-expansion": {
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -12975,6 +15703,16 @@
 			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001487.tgz",
 			"integrity": "sha512-83564Z3yWGqXsh2vaH/mhXfEM0wX+NlBCm1jYHOb97TrTWJEmPTccZgeLTPBUUb0PNVo+oomb7wkimZBIERClA==",
 			"dev": true
+		},
+		"celebrate": {
+			"version": "15.0.1",
+			"resolved": "https://registry.npmjs.org/celebrate/-/celebrate-15.0.1.tgz",
+			"integrity": "sha512-K2y221k10u+K2t9w25802qXh8h1mVWZf+6pl7zHdlhhwzrOSQFnnw+GsR8k17oyn4Y3fVErBGsO/+CeW8N7aRQ==",
+			"requires": {
+				"escape-html": "1.0.3",
+				"joi": "17.x.x",
+				"lodash": "4.17.x"
+			}
 		},
 		"chalk": {
 			"version": "4.1.2",
@@ -14288,6 +17026,14 @@
 			"resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
 			"integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
 			"dev": true
+		},
+		"fast-xml-parser": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.1.2.tgz",
+			"integrity": "sha512-CDYeykkle1LiA/uqQyNwYpFbyF6Axec6YapmpUP+/RHWIoR1zKjocdvNaTsxCxZzQ6v9MLXaSYm9Qq0thv0DHg==",
+			"requires": {
+				"strnum": "^1.0.5"
+			}
 		},
 		"fastest-levenshtein": {
 			"version": "1.0.16",
@@ -15971,8 +18717,7 @@
 		"lodash": {
 			"version": "4.17.21",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-			"dev": true
+			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
 		},
 		"lodash.clonedeep": {
 			"version": "4.5.0",
@@ -17765,6 +20510,11 @@
 				}
 			}
 		},
+		"strnum": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
+			"integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
+		},
 		"strtok3": {
 			"version": "6.3.0",
 			"resolved": "https://registry.npmjs.org/strtok3/-/strtok3-6.3.0.tgz",
@@ -18101,8 +20851,7 @@
 		"tslib": {
 			"version": "1.14.1",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-			"dev": true
+			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
 		},
 		"tsutils": {
 			"version": "3.21.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -22,6 +22,7 @@
 		"pino-pretty": "^10.0.0",
 		"prettier": "^2.8.8",
 		"serverless": "^3.31.0",
+		"serverless-dotenv-plugin": "^6.0.0",
 		"serverless-plugin-typescript": "^2.1.4",
 		"ts-jest": "^29.1.0",
 		"ts-node": "^10.9.1",

--- a/backend/package.json
+++ b/backend/package.json
@@ -5,7 +5,7 @@
 		"dev": "cp env/.env.local .env && nodemon src/index.ts",
 		"test": "jest",
 		"build": "tsc",
-        "deploy:dev": "cp env/.env.development .env && serverless deploy --stage dev",
+		"deploy:dev": "cp env/.env.development .env && serverless deploy --stage dev",
 		"start": "cp env/.env.production .env && node build/index.js"
 	},
 	"devDependencies": {
@@ -28,8 +28,10 @@
 		"typescript": "^5.0.4"
 	},
 	"dependencies": {
+		"@aws-sdk/client-lambda": "^3.338.0",
 		"@vendia/serverless-express": "^4.10.4",
 		"body-parser": "^1.20.2",
+		"celebrate": "^15.0.1",
 		"convict": "^6.2.4",
 		"dotenv": "^16.0.3",
 		"express": "^4.18.2",

--- a/backend/package.json
+++ b/backend/package.json
@@ -39,7 +39,7 @@
 		"joi": "^17.9.2",
 		"pino": "^8.14.1",
 		"pino-http": "^8.3.3",
-		"swagger-jsdoc": "^6.2.8",
-		"swagger-ui-express": "^4.6.3"
+		"swagger-ui-express": "^4.6.3",
+		"yaml": "^2.3.0"
 	}
 }

--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -1,9 +1,9 @@
 service: backend
 frameworkVersion: '3'
 
-useDotenv: true
 plugins:
   - serverless-plugin-typescript
+  - serverless-dotenv-plugin
 
 provider:
   name: aws

--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -8,6 +8,7 @@ plugins:
 provider:
   name: aws
   runtime: nodejs18.x
+  region: ap-southeast-1
   iam:
     role:
       statements: # give this lambda permission to invoke the execute service's lambda

--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -8,6 +8,12 @@ plugins:
 provider:
   name: aws
   runtime: nodejs18.x
+  iam:
+    role:
+      statements: # give this lambda permission to invoke the execute service's lambda
+        - Effect: Allow
+          Action: 'lambda:InvokeFunction'
+          Resource: arn:aws:lambda:${aws:region}:${aws:accountId}:function:executor-${sls:stage}
 
 functions:
   api:

--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -14,6 +14,6 @@ functions:
     handler: src/index.handler
     events:
       - httpApi:
-          method: GET
+          method: '*'
           path: /{any+}
     

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -14,6 +14,18 @@ const config = convict({
 		default: 8000,
 		env: 'PORT',
 	},
+    executorRegion: {
+        doc: 'The region hosting the executor service\'s Lambda',
+        format: '*',
+        default: 'us-east-1',
+        env: 'EXECUTOR_REGION'
+    },
+    executorName: {
+        doc: 'Name of the executor service\'s Lambda',
+        format: '*',
+        default: 'executor',
+        env: 'EXECUTOR_NAME'
+    }
 })
 
 export default config

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -17,7 +17,7 @@ const config = convict({
     executorRegion: {
         doc: 'The region hosting the executor service\'s Lambda',
         format: '*',
-        default: 'us-east-1',
+        default: 'ap-southeast-1',
         env: 'EXECUTOR_REGION'
     },
     executorName: {

--- a/backend/src/docs/docs.route.ts
+++ b/backend/src/docs/docs.route.ts
@@ -1,20 +1,12 @@
 import express from 'express'
-import swaggerJsdoc from 'swagger-jsdoc'
 import swaggerUi from 'swagger-ui-express'
+import fs from 'fs'
+import YAML from 'yaml'
 
-const options = {
-	definition: {
-		openapi: '3.0.0',
-		info: {
-			title: 'CodeSketcher API',
-			version: '0.0.1',
-		},
-	},
-	apis: ['./src/*/*.route.ts'],
-}
-const openapiSpecification = swaggerJsdoc(options)
+const file = fs.readFileSync('./swagger.yml', 'utf8')
+const swaggerDocument = YAML.parse(file)
 const router = express()
 
-router.use('/api-docs', swaggerUi.serve, swaggerUi.setup(openapiSpecification))
+router.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerDocument))
 
 export default router

--- a/backend/src/execute/execute.route.ts
+++ b/backend/src/execute/execute.route.ts
@@ -4,15 +4,6 @@ import execute from './execute.service'
 
 const router = express()
 
-/**
- * @openapi
- * /execute:
- *   get:
- *     description: Executes the given code and returns information about variables at each step.
- *     responses:
- *       200:
- *         description: TODO - decide on format of data
- */
 router.post(
 	'/execute',
 	celebrate({

--- a/backend/src/execute/execute.route.ts
+++ b/backend/src/execute/execute.route.ts
@@ -1,4 +1,6 @@
 import express from 'express'
+import { celebrate, Joi, Segments } from 'celebrate'
+import execute from './execute.service'
 
 const router = express()
 
@@ -11,9 +13,18 @@ const router = express()
  *       200:
  *         description: TODO - decide on format of data
  */
-router.post('/execute', (_req, res) => {
-	// TODO
-	res.send('TODO')
-})
+router.post(
+	'/execute',
+	celebrate({
+		[Segments.BODY]: Joi.object().keys({
+			code: Joi.string().required(),
+		}),
+	}),
+	async (req, res) => {
+        const code = req.body.code as string;
+		const response = await execute(code)
+        res.status(200).json(response)
+	}
+)
 
 export default router

--- a/backend/src/execute/execute.service.ts
+++ b/backend/src/execute/execute.service.ts
@@ -1,0 +1,17 @@
+import { InvokeCommand, Lambda } from '@aws-sdk/client-lambda'
+import config from '../config'
+
+const client = new Lambda({ region: config.get('executorRegion') })
+
+export default async function execute(code: string) {
+	const command = new InvokeCommand({
+		FunctionName: config.get('executorName'),
+		Payload: Buffer.from(JSON.stringify(code)),
+	})
+	const { Payload } = await client.send(command)
+	if (Payload === undefined) {
+		return null
+	}
+	const result = JSON.parse(Buffer.from(Payload).toString())
+	return result
+}

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,7 +1,8 @@
-import express from 'express'
+import express, { ErrorRequestHandler } from 'express'
 import bodyParser from 'body-parser'
 import pinoHttp from 'pino-http'
 import serverlessExpress from '@vendia/serverless-express'
+import { isCelebrateError } from 'celebrate'
 import config from './config'
 import logger from './logger'
 import docsRouter from './docs/docs.route'
@@ -18,6 +19,32 @@ app.use(bodyParser.json())
 
 app.use(docsRouter)
 app.use(executeRouter)
+
+// handles all celebrate errors (i.e. request validation error)
+const celebrateErrorHandler: ErrorRequestHandler = (err, _req, res, next) => {
+	if (isCelebrateError(err)) {
+		const allMessages: string[] = []
+		err.details.forEach((value) => allMessages.push(value.message))
+		res.status(422).json({ message: allMessages.join('\n') })
+	} else {
+		next(err)
+	}
+}
+app.use(celebrateErrorHandler)
+
+// handles all other types of errors
+const httpErrorHandler: ErrorRequestHandler = (err, _req, res, _next) => {
+	logger.error('sending json error response', err)
+
+	if (err instanceof URIError) {
+		// this error happens when someone types a malformed url such as /%c0
+		res.sendStatus(400)
+	} else {
+		// generic error, return 500
+		res.status(500).json({ message: 'Something went wrong, please try again.' })
+	}
+}
+app.use(httpErrorHandler)
 
 if (config.get('env') === 'local') {
 	app.listen(config.get('port'), () => {

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -34,7 +34,7 @@ app.use(celebrateErrorHandler)
 
 // handles all other types of errors
 const httpErrorHandler: ErrorRequestHandler = (err, _req, res, _next) => {
-	logger.error('sending json error response', err)
+	logger.error({ message: 'sending json error response', error: err })
 
 	if (err instanceof URIError) {
 		// this error happens when someone types a malformed url such as /%c0

--- a/backend/swagger.yml
+++ b/backend/swagger.yml
@@ -1,0 +1,49 @@
+openapi: 3.0.3
+info:
+  title: CodeSketcher
+  description: |-
+    Documentation for the backend API of CodeSketcher.
+  version: 0.0.1
+paths:
+  /execute:
+    post:
+      description: Get information about how variables change throughout code execution.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                code:
+                  type: string
+                  example: 'a = 1\nb = 2'
+        required: true
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  data:
+                    $ref: '#/components/schemas/ExecutionInformationArray'
+components:
+  schemas:
+    ExecutionInformation:
+      type: object
+      properties:
+        line_number:
+          type: integer
+          example: 1
+        variable_changes:
+          type: object
+          description: A mapping from every changed variable to their new value.
+          example:
+            a: 1
+    ExecutionInformationArray:
+      type: array
+      items:
+        $ref: '#/components/schemas/ExecutionInformation'

--- a/services/executor/executor/main.py
+++ b/services/executor/executor/main.py
@@ -2,10 +2,11 @@ import bdb
 import copy
 
 class Debugger(bdb.Bdb):
-    is_tracing = False
-    data = []
-    last_line_number = -1
-    last_variables = {}
+    def __init__(self):
+        self.is_tracing = False
+        self.data = []
+        self.last_line_number = -1
+        self.last_variables = {}
 
     def user_line(self, frame):
         if not self.is_tracing:

--- a/services/executor/executor/main.py
+++ b/services/executor/executor/main.py
@@ -3,6 +3,7 @@ import copy
 
 class Debugger(bdb.Bdb):
     def __init__(self):
+        super().__init__()
         self.is_tracing = False
         self.data = []
         self.last_line_number = -1

--- a/services/executor/serverless.yml
+++ b/services/executor/serverless.yml
@@ -4,6 +4,7 @@ frameworkVersion: '3'
 provider:
   name: aws
   runtime: python3.10
+  region: ap-southeast-1
 
 functions:
   executor:


### PR DESCRIPTION
This PR adds (very simple) functionality to the `POST /execute` endpoint of the backend API, by linking it to the executor Lambda.

- Added input validation for HTTP requests with celebrate and joi
- Updated documentation for backend to use one swagger.yml file instead of swagger-jsdoc. This is so that we can use the [swagger editor](https://editor.swagger.io/)
- Gave `lambda:InvokeFunction` permissions to the backend Lambda, allowing it to invoke the executor Lambda

<img width="627" alt="Screenshot 2023-05-25 at 6 14 27 PM" src="https://github.com/huajun07/codesketcher/assets/30954848/012ce87f-05f1-4f30-890b-9d3a6f5cd560">

Next steps:
- Investigate how the Python debugger behaves with various constructs like functions or input/output
- Investigate possible errors thrown and handle them appropriately
