### PR TITLE
Feat: Interval Playing

### DIFF
--- a/frontend/src/app/Router.tsx
+++ b/frontend/src/app/Router.tsx
@@ -7,10 +7,21 @@ interface RouteType {
   component: JSX.Element
 }
 
+const testInstructions = [
+  { line_number: 1, variable_changes: { a: 1 } },
+  { line_number: 2, variable_changes: { b: 'hello world' } },
+  { line_number: 1, variable_changes: { b: 'hello world2' } },
+  { line_number: 2, variable_changes: { b: 'hello world3' } },
+  { line_number: 1, variable_changes: { b: 'hello world4' } },
+  { line_number: 2, variable_changes: { b: 'hello world5' } },
+  { line_number: 1, variable_changes: { b: 'hello world6' } },
+  { line_number: 2, variable_changes: { b: 'hello world7' } },
+]
+
 export const routes: RouteType[] = [
   {
     path: '/',
-    component: <Main />,
+    component: <Main instructions={testInstructions} />,
   },
 ]
 

--- a/frontend/src/components/ControlBar.tsx
+++ b/frontend/src/components/ControlBar.tsx
@@ -3,7 +3,11 @@ import {
   Box,
   Flex,
   IconButton,
-  Input,
+  NumberDecrementStepper,
+  NumberIncrementStepper,
+  NumberInput,
+  NumberInputField,
+  NumberInputStepper,
   Slider,
   SliderFilledTrack,
   SliderThumb,
@@ -19,6 +23,9 @@ interface ControlBarProps {
   playing: boolean
   length: number
   curSpeed: number
+  disabled: boolean
+  setSpeed: (speed: number) => void
+  togglePlaying: () => void
 }
 
 export const ControlBar = (props: ControlBarProps) => {
@@ -26,13 +33,15 @@ export const ControlBar = (props: ControlBarProps) => {
   return (
     <>
       <Flex flexDirection="column">
-        <Box px="15px" py="0px">
+        <Box px="15px" paddingTop="10px">
           <Slider
             value={props.curIdx}
             min={0}
             max={props.length}
             step={1}
             size="lg"
+            focusThumbOnChange={false}
+            isDisabled={props.disabled}
           >
             <SliderTrack>
               <Box position="relative" right={10} />
@@ -44,7 +53,21 @@ export const ControlBar = (props: ControlBarProps) => {
         <Flex>
           <Stack direction="row" align="center" px="10px">
             <Text> Speed</Text>
-            <Input value={props.curSpeed} w="60px" textAlign="center" />
+            <NumberInput
+              maxW="80px"
+              mr="2rem"
+              value={props.curSpeed}
+              onChange={(v) => props.setSpeed(Number(v))}
+              min={1}
+              max={1000}
+              isDisabled={props.disabled}
+            >
+              <NumberInputField />
+              <NumberInputStepper>
+                <NumberIncrementStepper />
+                <NumberDecrementStepper />
+              </NumberInputStepper>
+            </NumberInput>
           </Stack>
           <Spacer />
           <Stack direction="row" align="center">
@@ -53,6 +76,7 @@ export const ControlBar = (props: ControlBarProps) => {
               background="none"
               size="lg"
               aria-label="Rewind"
+              isDisabled={props.disabled}
               icon={<FaBackward color={buttonColor} />}
             />
             <IconButton
@@ -60,6 +84,7 @@ export const ControlBar = (props: ControlBarProps) => {
               background="none"
               size="lg"
               aria-label="Play/Pause"
+              isDisabled={props.disabled || props.curIdx === props.length}
               icon={
                 props.playing ? (
                   <FaPause color={buttonColor} />
@@ -67,19 +92,34 @@ export const ControlBar = (props: ControlBarProps) => {
                   <FaPlay color={buttonColor} />
                 )
               }
+              onClick={props.togglePlaying}
             />
             <IconButton
               isRound={true}
               background="none"
               size="lg"
               aria-label="Forward"
+              isDisabled={props.disabled}
               icon={<FaForward color={buttonColor} />}
             />
           </Stack>
           <Spacer />
           <Stack direction="row" align="center" px="10px">
             <Text> Step</Text>
-            <Input value={props.curIdx} w="60px" textAlign="center" />
+            <NumberInput
+              maxW="80px"
+              mr="2rem"
+              value={props.curIdx}
+              min={0}
+              max={props.length}
+              isDisabled={props.disabled}
+            >
+              <NumberInputField />
+              <NumberInputStepper>
+                <NumberIncrementStepper />
+                <NumberDecrementStepper />
+              </NumberInputStepper>
+            </NumberInput>
           </Stack>
         </Flex>
       </Flex>

--- a/frontend/src/components/ControlBar.tsx
+++ b/frontend/src/components/ControlBar.tsx
@@ -1,0 +1,88 @@
+import { FaBackward, FaForward, FaPause, FaPlay } from 'react-icons/fa'
+import {
+  Box,
+  Flex,
+  IconButton,
+  Input,
+  Slider,
+  SliderFilledTrack,
+  SliderThumb,
+  SliderTrack,
+  Spacer,
+  Stack,
+  Text,
+  useColorModeValue,
+} from '@chakra-ui/react'
+
+interface ControlBarProps {
+  curIdx: number
+  playing: boolean
+  length: number
+  curSpeed: number
+}
+
+export const ControlBar = (props: ControlBarProps) => {
+  const buttonColor = useColorModeValue('#3182ce', '#90cdf4')
+  return (
+    <>
+      <Flex flexDirection="column">
+        <Box px="15px" py="0px">
+          <Slider
+            value={props.curIdx}
+            min={0}
+            max={props.length}
+            step={1}
+            size="lg"
+          >
+            <SliderTrack>
+              <Box position="relative" right={10} />
+              <SliderFilledTrack />
+            </SliderTrack>
+            <SliderThumb boxSize={4} />
+          </Slider>
+        </Box>
+        <Flex>
+          <Stack direction="row" align="center" px="10px">
+            <Text> Speed</Text>
+            <Input value={props.curSpeed} w="60px" textAlign="center" />
+          </Stack>
+          <Spacer />
+          <Stack direction="row" align="center">
+            <IconButton
+              isRound={true}
+              background="none"
+              size="lg"
+              aria-label="Rewind"
+              icon={<FaBackward color={buttonColor} />}
+            />
+            <IconButton
+              isRound={true}
+              background="none"
+              size="lg"
+              aria-label="Play/Pause"
+              icon={
+                props.playing ? (
+                  <FaPause color={buttonColor} />
+                ) : (
+                  <FaPlay color={buttonColor} />
+                )
+              }
+            />
+            <IconButton
+              isRound={true}
+              background="none"
+              size="lg"
+              aria-label="Forward"
+              icon={<FaForward color={buttonColor} />}
+            />
+          </Stack>
+          <Spacer />
+          <Stack direction="row" align="center" px="10px">
+            <Text> Step</Text>
+            <Input value={props.curIdx} w="60px" textAlign="center" />
+          </Stack>
+        </Flex>
+      </Flex>
+    </>
+  )
+}

--- a/frontend/src/components/DataTable.tsx
+++ b/frontend/src/components/DataTable.tsx
@@ -14,7 +14,8 @@ import {
 } from '@chakra-ui/react'
 
 interface RowDataProps {
-  val: string | number
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  val: any
 }
 
 const RowData = (props: RowDataProps) => {

--- a/frontend/src/components/VisualArea.tsx
+++ b/frontend/src/components/VisualArea.tsx
@@ -1,0 +1,11 @@
+import { Center } from '@chakra-ui/react'
+
+export const VisualArea = () => {
+  return (
+    <>
+      <Center flex={1} background="gray">
+        Visual Stuff Here (In progress)
+      </Center>
+    </>
+  )
+}

--- a/frontend/src/components/index.ts
+++ b/frontend/src/components/index.ts
@@ -1,5 +1,7 @@
 export * from './CodeIDE'
 export * from './CodeIDEButtons'
+export * from './ControlBar'
 export * from './DataTable'
 export * from './InputIDE'
 export * from './NavBar'
+export * from './VisualArea'

--- a/frontend/src/pages/Main/Main.tsx
+++ b/frontend/src/pages/Main/Main.tsx
@@ -1,7 +1,14 @@
 import { useState } from 'react'
 import { Box, Flex } from '@chakra-ui/react'
 
-import { CodeIDE, CodeIDEButtons, DataTable, InputIDE } from 'components'
+import {
+  CodeIDE,
+  CodeIDEButtons,
+  ControlBar,
+  DataTable,
+  InputIDE,
+  VisualArea,
+} from 'components'
 
 export const Main = () => {
   const [editing, setEditing] = useState(true)
@@ -23,6 +30,14 @@ export const Main = () => {
         <Flex w="500px" borderRightWidth="1px" flexDirection="column">
           <DataTable data={test} />
           <InputIDE />
+        </Flex>
+        <Flex flex={1} flexDirection="column">
+          <Flex flex={1}>
+            <VisualArea />
+          </Flex>
+          <Box>
+            <ControlBar curIdx={2} length={10} playing={false} curSpeed={10} />
+          </Box>
         </Flex>
       </Flex>
     </>

--- a/frontend/src/pages/Main/Main.tsx
+++ b/frontend/src/pages/Main/Main.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { Box, Flex } from '@chakra-ui/react'
+import { Box, Flex, useInterval } from '@chakra-ui/react'
 
 import {
   CodeIDE,
@@ -10,25 +10,85 @@ import {
   VisualArea,
 } from 'components'
 
-export const Main = () => {
+interface dataVal {
+  name: string
+  value: string | number
+}
+
+interface instruction {
+  line_number: number
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  variable_changes: Record<string, any>
+}
+
+interface MainProps {
+  instructions: instruction[]
+}
+
+export const Main = (props: MainProps) => {
   const [editing, setEditing] = useState(true)
-  const test = [
-    { name: 'a', value: 2 },
-    { name: 'b', value: 'hellow world' },
-    { name: 'c', value: 3.02 },
-  ]
+  const [data, setData] = useState<dataVal[]>([])
+  const [isPlaying, setPlaying] = useState(false)
+  const [speed, setSpeed] = useState<number>(1)
+  const [curIdx, setCurIdx] = useState(0)
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const updateData = (name: string, value: any) => {
+    const idx = data.findIndex((item) => item.name === name)
+    const tempData = data
+    const newData = { name, value }
+    if (idx !== -1) tempData[idx] = newData
+    else tempData.push(newData)
+    setData(tempData)
+  }
+
+  useInterval(
+    () => {
+      setCurIdx(curIdx + 1) // This is updated after the hook is called
+      // sanity check
+      if (curIdx >= 0 && curIdx < props.instructions.length) {
+        const newInstructions = props.instructions[curIdx].variable_changes
+        console.log(curIdx, newInstructions, props.instructions)
+        for (const [key, value] of Object.entries(newInstructions)) {
+          updateData(key, value)
+        }
+      }
+      if (curIdx >= props.instructions.length - 1) {
+        setPlaying(false)
+      }
+    },
+    isPlaying ? Math.ceil(1000 / speed) : null,
+  )
+
+  const toggleEditing = () => {
+    if (editing) {
+      // Start playing
+      /* Fetch instructions TODO*/
+      setCurIdx(0)
+      setData([])
+      setPlaying(true)
+      console.log('Start playing')
+    } else {
+      // Stop playing
+      setPlaying(false)
+    }
+    setEditing(!editing)
+  }
+
   return (
     <>
       <Flex>
         <Box w="500px" overflowX="scroll" borderRightWidth="1px">
-          <CodeIDEButtons
-            editing={editing}
-            toggleMode={() => setEditing(!editing)}
+          <CodeIDEButtons editing={editing} toggleMode={toggleEditing} />
+          <CodeIDE
+            editable={editing}
+            lineHighlight={
+              curIdx > 0 ? props.instructions[curIdx - 1].line_number : 0
+            }
           />
-          <CodeIDE editable={editing} lineHighlight={2} />
         </Box>
         <Flex w="500px" borderRightWidth="1px" flexDirection="column">
-          <DataTable data={test} />
+          <DataTable data={data} />
           <InputIDE />
         </Flex>
         <Flex flex={1} flexDirection="column">
@@ -36,7 +96,17 @@ export const Main = () => {
             <VisualArea />
           </Flex>
           <Box>
-            <ControlBar curIdx={2} length={10} playing={false} curSpeed={10} />
+            <ControlBar
+              curIdx={curIdx}
+              length={props.instructions.length}
+              playing={isPlaying}
+              curSpeed={speed}
+              setSpeed={setSpeed}
+              togglePlaying={() => {
+                setPlaying(!isPlaying)
+              }}
+              disabled={editing}
+            />
           </Box>
         </Flex>
       </Flex>

--- a/frontend/src/pages/Main/Main.tsx
+++ b/frontend/src/pages/Main/Main.tsx
@@ -35,11 +35,10 @@ export const Main = (props: MainProps) => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const updateData = (name: string, value: any) => {
     const idx = data.findIndex((item) => item.name === name)
-    const tempData = data
     const newData = { name, value }
-    if (idx !== -1) tempData[idx] = newData
-    else tempData.push(newData)
-    setData(tempData)
+    if (idx !== -1) data[idx] = newData
+    else data.push(newData)
+    setData(data)
   }
 
   useInterval(


### PR DESCRIPTION
## Features
- Setup Control Bar to control the playing interval speed and current state
- Added initial logic flow for the playing of the simulation

**Notes**
- Have added some usage of `// eslint-disable-next-line @typescript-eslint/no-explicit-any` since the variable value is not fixed and not determined at this point in time
- Also note that currently the updating of the state only allows increments of the idx. This will be modified in the next PR to rebuild the state instead of incremental updates

**Limitations**
- Note that this PR does not yet call the backend API to retrieve the instructional values of the code
- This PR also currently does not implement the manual changing of the current state either via the slider or number input
These limitations will be addressed in the next PRs

## Future tasks
- Currently the changing of the state completely re-renders the table as the data attribute is modified completely, this is inefficient when there are only minimal changes. Will look into only re-rendering the modified data. However this is a low-priority task


## Tests
Have not setup tests however tested locally with `npm run start` and `npm run build`




