### PR TITLE
Feat: Manual Selection of Current State

### DIFF
--- a/frontend/src/components/ControlBar.tsx
+++ b/frontend/src/components/ControlBar.tsx
@@ -24,8 +24,11 @@ interface ControlBarProps {
   length: number
   curSpeed: number
   disabled: boolean
+  wasPlaying: boolean
   setSpeed: (speed: number) => void
   togglePlaying: () => void
+  setWasPlaying: (newVal: boolean) => void
+  setCurIdx: (idx: number) => void
 }
 
 export const ControlBar = (props: ControlBarProps) => {
@@ -42,6 +45,23 @@ export const ControlBar = (props: ControlBarProps) => {
             size="lg"
             focusThumbOnChange={false}
             isDisabled={props.disabled}
+            onChange={props.setCurIdx}
+            onChangeStart={
+              props.playing
+                ? () => {
+                    props.setWasPlaying(true)
+                    props.togglePlaying()
+                  }
+                : void 0
+            }
+            onChangeEnd={
+              props.wasPlaying
+                ? () => {
+                    props.setWasPlaying(false)
+                    props.togglePlaying()
+                  }
+                : void 0
+            }
           >
             <SliderTrack>
               <Box position="relative" right={10} />
@@ -113,6 +133,7 @@ export const ControlBar = (props: ControlBarProps) => {
               min={0}
               max={props.length}
               isDisabled={props.disabled}
+              onChange={(v) => props.setCurIdx(Number(v))}
             >
               <NumberInputField />
               <NumberInputStepper>

--- a/frontend/src/pages/Main/Main.tsx
+++ b/frontend/src/pages/Main/Main.tsx
@@ -29,16 +29,16 @@ export const Main = (props: MainProps) => {
   const [editing, setEditing] = useState(true)
   const [data, setData] = useState<dataVal[]>([])
   const [isPlaying, setPlaying] = useState(false)
+  const [wasPlaying, setWasPlaying] = useState(false)
   const [speed, setSpeed] = useState<number>(1)
   const [curIdx, setCurIdx] = useState(0)
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const updateData = (name: string, value: any) => {
-    const idx = data.findIndex((item) => item.name === name)
+  const updateData = (name: string, value: any, dataArr: dataVal[]) => {
+    const idx = dataArr.findIndex((item) => item.name === name)
     const newData = { name, value }
-    if (idx !== -1) data[idx] = newData
-    else data.push(newData)
-    setData(data)
+    if (idx !== -1) dataArr[idx] = newData
+    else dataArr.push(newData)
   }
 
   useInterval(
@@ -49,8 +49,9 @@ export const Main = (props: MainProps) => {
         const newInstructions = props.instructions[curIdx].variable_changes
         console.log(curIdx, newInstructions, props.instructions)
         for (const [key, value] of Object.entries(newInstructions)) {
-          updateData(key, value)
+          updateData(key, value, data)
         }
+        setData(data)
       }
       if (curIdx >= props.instructions.length - 1) {
         setPlaying(false)
@@ -59,6 +60,18 @@ export const Main = (props: MainProps) => {
     isPlaying ? Math.ceil(1000 / speed) : null,
   )
 
+  const setDataIdx = (idx: number) => {
+    const newData: dataVal[] = []
+    for (let i = 0; i < idx; i++) {
+      const newInstructions = props.instructions[i].variable_changes
+      for (const [key, value] of Object.entries(newInstructions)) {
+        updateData(key, value, newData)
+      }
+    }
+    setData(newData)
+    setCurIdx(idx)
+  }
+
   const toggleEditing = () => {
     if (editing) {
       // Start playing
@@ -66,6 +79,7 @@ export const Main = (props: MainProps) => {
       setCurIdx(0)
       setData([])
       setPlaying(true)
+      setWasPlaying(false)
       console.log('Start playing')
     } else {
       // Stop playing
@@ -104,7 +118,10 @@ export const Main = (props: MainProps) => {
               togglePlaying={() => {
                 setPlaying(!isPlaying)
               }}
+              setCurIdx={setDataIdx}
               disabled={editing}
+              wasPlaying={wasPlaying}
+              setWasPlaying={setWasPlaying}
             />
           </Box>
         </Flex>

--- a/frontend/src/pages/Main/Main.tsx
+++ b/frontend/src/pages/Main/Main.tsx
@@ -43,9 +43,9 @@ export const Main = (props: MainProps) => {
 
   useInterval(
     () => {
-      setCurIdx(curIdx + 1) // This is updated after the hook is called
       // sanity check
       if (curIdx >= 0 && curIdx < props.instructions.length) {
+        setCurIdx(curIdx + 1) // This is updated after the hook is called
         const newInstructions = props.instructions[curIdx].variable_changes
         console.log(curIdx, newInstructions, props.instructions)
         for (const [key, value] of Object.entries(newInstructions)) {

--- a/frontend/src/pages/Main/Main.tsx
+++ b/frontend/src/pages/Main/Main.tsx
@@ -116,7 +116,8 @@ export const Main = (props: MainProps) => {
               curSpeed={speed}
               setSpeed={setSpeed}
               togglePlaying={() => {
-                setPlaying(!isPlaying)
+                if (isPlaying || curIdx < props.instructions.length)
+                  setPlaying(!isPlaying)
               }}
               setCurIdx={setDataIdx}
               disabled={editing}


### PR DESCRIPTION
## Features
- Setup Slider and Number Input to manually control the current state

**Notes**
- Refactored the data building function to accept what array to add to for better code reusability

**Limitations**
- Note that this PR does not yet call the backend API to retrieve the instructional values of the code
These limitations will be addressed in the next PRs

## Tests
Have not setup tests however tested locally with `npm run start` and `npm run build`
The site can also be tested at this link: https://feat-manual-selection.d1fr5et3wgts3j.amplifyapp.com/




