### PR TITLE
fix: package swagger.yml so that it is available to the lambda

### DIFF
--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -16,6 +16,10 @@ provider:
           Action: 'lambda:InvokeFunction'
           Resource: arn:aws:lambda:${aws:region}:${aws:accountId}:function:executor-${sls:stage}
 
+package:
+  include:
+    - ./swagger.yml # needed for generating documentation
+
 functions:
   api:
     handler: src/index.handler


### PR DESCRIPTION
<img width="405" alt="Screenshot 2023-05-26 at 6 08 42 PM" src="https://github.com/huajun07/codesketcher/assets/30954848/400165bb-3af5-45bf-a4b5-6136692a2847">

The lambda needs to read "swagger.yml" in order to generate the documentation, else it will crash with a file not found exception.

Updated serverless.yml configuration to package swagger.yml into the lambda. Tested by [deploying](https://github.com/huajun07/codesketcher/actions/runs/5089682009/jobs/9147620296) to dev.