### PR TITLE
fix: configure serverless to allow all CORS requests

### DIFF
--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -15,6 +15,8 @@ provider:
         - Effect: Allow
           Action: 'lambda:InvokeFunction'
           Resource: arn:aws:lambda:${aws:region}:${aws:accountId}:function:executor-${sls:stage}
+  httpApi:
+    cors: true
 
 package:
   include:


### PR DESCRIPTION
This PR configures the backend lambda to accept all CORS requests so that the frontend can connect to it. Tested with this [deployment](https://github.com/huajun07/codesketcher/actions/runs/5089870178/jobs/9148011177).