### PR TITLE
fix: Stringfy Return Value

### DIFF
--- a/frontend/src/components/DataTable.tsx
+++ b/frontend/src/components/DataTable.tsx
@@ -19,7 +19,7 @@ interface RowDataProps {
 }
 
 const RowData = (props: RowDataProps) => {
-  return <Text>{props.val}</Text>
+  return <Text>{JSON.stringify(props.val)}</Text>
 }
 
 interface dataVal {


### PR DESCRIPTION
# Bug Fix
- The display of non-simple data types was incorrectly and sometimes causes the site to crash

# Solution
- Use `JSON.stringfy` to convert the data types into string
**Notes**
- This is under the assumption that the provided data is JSON serializable. Which should be valid as a POST request data response. Invalid data types should instead by converted by the server.

# Tests
![image](https://github.com/huajun07/codesketcher/assets/35941406/87a8d22f-775a-4b77-8ebc-7c1b22bfd425)
