### PR TITLE
Chore: Visual Improvements

### DIFF
--- a/frontend/src/components/CodeIDE.tsx
+++ b/frontend/src/components/CodeIDE.tsx
@@ -12,12 +12,19 @@ interface codeIDEProps {
 }
 
 export const CodeIDE = (props: codeIDEProps) => {
+  const placeholder = "Enter your python code here!\nE.g. print('hello world')"
   return (
     <CodeMirror
       value={props.code}
       height="calc(100vh - 144px)"
       editable={props.editable}
       readOnly={!props.editable}
+      placeholder={placeholder}
+      autoFocus={true}
+      basicSetup={{
+        highlightActiveLineGutter: props.editable,
+        highlightActiveLine: props.editable,
+      }}
       extensions={[
         zebraStripes({
           lineNumber: [props.lineHighlight || 0],

--- a/frontend/src/components/CodeIDEButtons.tsx
+++ b/frontend/src/components/CodeIDEButtons.tsx
@@ -11,6 +11,7 @@ import {
 
 interface CodeIDEButtonProps {
   editing: boolean
+  isDisabled: boolean
   toggleMode: () => void
 }
 
@@ -37,6 +38,7 @@ export const CodeIDEButtons = (props: CodeIDEButtonProps) => {
             colorScheme="blue"
             variant="solid"
             onClick={props.toggleMode}
+            isDisabled={props.isDisabled}
           >
             {props.editing ? 'Run' : 'Edit'}
           </Button>

--- a/frontend/src/pages/Main/Main.tsx
+++ b/frontend/src/pages/Main/Main.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { Box, Flex, useInterval } from '@chakra-ui/react'
+import { Box, Center, Flex, Spinner, useInterval } from '@chakra-ui/react'
 
 import { getInstructions, instruction } from 'utils/executor'
 import {
@@ -24,7 +24,8 @@ export const Main = () => {
   const [wasPlaying, setWasPlaying] = useState(false)
   const [speed, setSpeed] = useState<number>(1)
   const [curIdx, setCurIdx] = useState(0)
-  const [code, setCode] = useState("print('hello world')")
+  const [code, setCode] = useState('')
+  const [loading, setLoading] = useState(false)
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const updateData = (name: string, value: any, dataArr: dataVal[]) => {
@@ -45,9 +46,11 @@ export const Main = () => {
           updateData(key, value, data)
         }
         setData(data)
+        setLoading(false)
       }
       if (curIdx >= instructions.length - 1) {
         setPlaying(false)
+        setLoading(false)
       }
     },
     isPlaying ? Math.ceil(1000 / speed) : null,
@@ -68,6 +71,7 @@ export const Main = () => {
   const toggleEditing = async () => {
     if (editing) {
       // Start playing
+      setLoading(true)
       const newInstructions = await getInstructions(code)
       setInstructions(newInstructions)
       setCurIdx(0)
@@ -85,7 +89,11 @@ export const Main = () => {
     <>
       <Flex>
         <Box w="500px" overflowX="scroll" borderRightWidth="1px">
-          <CodeIDEButtons editing={editing} toggleMode={toggleEditing} />
+          <CodeIDEButtons
+            editing={editing}
+            toggleMode={toggleEditing}
+            isDisabled={loading}
+          />
           <CodeIDE
             code={code}
             setCode={setCode}
@@ -95,31 +103,52 @@ export const Main = () => {
             }
           />
         </Box>
-        <Flex w="500px" borderRightWidth="1px" flexDirection="column">
-          <DataTable data={data} />
-          <InputIDE />
-        </Flex>
-        <Flex flex={1} flexDirection="column">
-          <Flex flex={1}>
-            <VisualArea />
+        <Flex position="relative" flex={1}>
+          {loading ? (
+            <Center
+              position="absolute"
+              h="100%"
+              w="100%"
+              bg="rgba(0, 0, 0, .5)"
+              zIndex={10}
+            >
+              <Spinner
+                thickness="10px"
+                speed="0.65s"
+                emptyColor="gray.200"
+                color="blue.500"
+                h="calc(20vh)"
+                w="calc(20vh)"
+                opacity={1}
+              />
+            </Center>
+          ) : null}
+          <Flex w="500px" borderRightWidth="1px" flexDirection="column">
+            <DataTable data={data} />
+            <InputIDE />
           </Flex>
-          <Box>
-            <ControlBar
-              curIdx={curIdx}
-              length={instructions.length}
-              playing={isPlaying}
-              curSpeed={speed}
-              setSpeed={setSpeed}
-              togglePlaying={() => {
-                if (isPlaying || curIdx < instructions.length)
-                  setPlaying(!isPlaying)
-              }}
-              setCurIdx={setDataIdx}
-              disabled={editing}
-              wasPlaying={wasPlaying}
-              setWasPlaying={setWasPlaying}
-            />
-          </Box>
+          <Flex flex={1} flexDirection="column">
+            <Flex flex={1}>
+              <VisualArea />
+            </Flex>
+            <Box>
+              <ControlBar
+                curIdx={curIdx}
+                length={instructions.length}
+                playing={isPlaying}
+                curSpeed={speed}
+                setSpeed={setSpeed}
+                togglePlaying={() => {
+                  if (isPlaying || curIdx < instructions.length)
+                    setPlaying(!isPlaying)
+                }}
+                setCurIdx={setDataIdx}
+                disabled={editing}
+                wasPlaying={wasPlaying}
+                setWasPlaying={setWasPlaying}
+              />
+            </Box>
+          </Flex>
         </Flex>
       </Flex>
     </>

--- a/frontend/src/pages/Main/Main.tsx
+++ b/frontend/src/pages/Main/Main.tsx
@@ -46,12 +46,11 @@ export const Main = () => {
           updateData(key, value, data)
         }
         setData(data)
-        setLoading(false)
       }
       if (curIdx >= instructions.length - 1) {
         setPlaying(false)
-        setLoading(false)
       }
+      setLoading(false)
     },
     isPlaying ? Math.ceil(1000 / speed) : null,
   )

--- a/frontend/src/utils/executor.ts
+++ b/frontend/src/utils/executor.ts
@@ -14,6 +14,7 @@ const getInstructions = async (code: string): Promise<instruction[]> => {
         code,
       },
     )
+    console.log(res)
     return res.data?.data || ([] as instruction[])
   } catch (err) {
     return []


### PR DESCRIPTION
# Changes
- Disabled active line highlighting when the code IDE is not in editing mode

| Before  | After |
| ------------- | ------------- |
| <img width="502" alt="image" src="https://github.com/huajun07/codesketcher/assets/35941406/7b2e9098-0661-4626-8772-15bdbfea4204">  | <img width="500" alt="image" src="https://github.com/huajun07/codesketcher/assets/35941406/6624b110-ec48-45ea-bb0c-d969ebf8d1a9">  |

- Use a placeholder instead of an actual value and auto focus the user to the IDE once the page loads 

| Before  | After |
| ------------- | ------------- |
| <img width="503" alt="image" src="https://github.com/huajun07/codesketcher/assets/35941406/9a211e9f-9f33-46dd-94c3-001a0827e14c"> | <img width="500" alt="image" src="https://github.com/huajun07/codesketcher/assets/35941406/53439d0b-fb33-4470-8c7a-ae40221c4fcb"> |

- Disable the edit button and display a loading overlay while the first state is being retrieved (Addressing issue https://github.com/huajun07/codesketcher/issues/17#issue-1727366595)
<img width="1313" alt="image" src="https://github.com/huajun07/codesketcher/assets/35941406/2422233f-6665-4226-a0e6-e1cc952e4cb3">

