### PR TITLE
Fix: backend deploy:prod script

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -6,7 +6,7 @@
 		"test": "jest",
 		"build": "tsc",
 		"deploy:dev": "cp env/.env.development .env && serverless deploy --stage dev",
-		"deploy:prod": "cp env/.env.prod .env && serverless deploy --stage prod",
+		"deploy:prod": "cp env/.env.production .env && serverless deploy --stage prod",
 		"start": "cp env/.env.production .env && node build/index.js"
 	},
 	"devDependencies": {


### PR DESCRIPTION
The deploy script copied the wrong file name (.env.prod instead of .env.production).