### PR TITLE
Feat/backend improvement

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,6 @@
     "source.fixAll.eslint": true
   },
   "editor.formatOnSave": true,
-  "eslint.validate": ["javascript"]
+  "eslint.validate": ["javascript"],
+  "python.formatting.provider": "black"
 }

--- a/backend/src/execute/execute.route.ts
+++ b/backend/src/execute/execute.route.ts
@@ -9,12 +9,14 @@ router.post(
 	celebrate({
 		[Segments.BODY]: Joi.object().keys({
 			code: Joi.string().required(),
+			input: Joi.string().allow(''),
 		}),
 	}),
 	async (req, res) => {
-        const code = req.body.code as string;
-		const response = await execute(code)
-        res.status(200).json(response)
+		const code = req.body.code as string
+		const input = req.body.input as string | undefined
+		const response = await execute({ code, input })
+		res.status(200).json(response)
 	}
 )
 

--- a/backend/src/execute/execute.service.ts
+++ b/backend/src/execute/execute.service.ts
@@ -3,10 +3,13 @@ import config from '../config'
 
 const client = new Lambda({ region: config.get('executorRegion') })
 
-export default async function execute(code: string) {
+export default async function execute(payload: {
+	code: string
+	input: string | undefined
+}) {
 	const command = new InvokeCommand({
 		FunctionName: config.get('executorName'),
-		Payload: Buffer.from(JSON.stringify(code)),
+		Payload: Buffer.from(JSON.stringify(payload)),
 	})
 	const { Payload } = await client.send(command)
 	if (Payload === undefined) {

--- a/backend/swagger.yml
+++ b/backend/swagger.yml
@@ -13,10 +13,14 @@ paths:
           application/json:
             schema:
               type: object
+              required: [code]
               properties:
                 code:
                   type: string
-                  example: 'a = 1\nb = 2'
+                  example: 'a = 1\nb = "test"'
+                input:
+                  type: string
+                  example: '1\n2\n3'
         required: true
       responses:
         '200':
@@ -42,7 +46,11 @@ components:
           type: object
           description: A mapping from every changed variable to their new value.
           example:
-            a: 1
+            a:
+              type: object
+              properties:
+                type: int
+                value: 1
     ExecutionInformationArray:
       type: array
       items:

--- a/frontend/src/components/DataTable.tsx
+++ b/frontend/src/components/DataTable.tsx
@@ -16,8 +16,7 @@ import {
 import { parsedVariable } from 'utils/executor'
 
 interface RowDataProps {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  val: any
+  val: parsedVariable
 }
 
 const RowData = (props: RowDataProps) => {

--- a/frontend/src/components/DataTable.tsx
+++ b/frontend/src/components/DataTable.tsx
@@ -13,6 +13,8 @@ import {
   useColorModeValue,
 } from '@chakra-ui/react'
 
+import { parsedVariable } from 'utils/executor'
+
 interface RowDataProps {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   val: any
@@ -24,7 +26,7 @@ const RowData = (props: RowDataProps) => {
 
 interface dataVal {
   name: string
-  value: string | number
+  value: parsedVariable
 }
 
 interface dataTableProps {

--- a/frontend/src/pages/Main/Main.tsx
+++ b/frontend/src/pages/Main/Main.tsx
@@ -92,7 +92,7 @@ export const Main = () => {
       setLoading(true)
       const { instructions: newInstructions, errorMessage } =
         await getInstructions(code)
-      if (!newInstructions) {
+      if (!newInstructions || errorMessage) {
         setLoading(false)
         toast({
           title: 'An Error Has Occured',

--- a/frontend/src/pages/Main/Main.tsx
+++ b/frontend/src/pages/Main/Main.tsx
@@ -8,7 +8,12 @@ import {
   useToast,
 } from '@chakra-ui/react'
 
-import { getInstructions, instruction } from 'utils/executor'
+import {
+  getInstructions,
+  instruction,
+  parsedVariable,
+  parseVariableValue,
+} from 'utils/executor'
 import {
   CodeIDE,
   CodeIDEButtons,
@@ -20,7 +25,7 @@ import {
 
 interface dataVal {
   name: string
-  value: string | number
+  value: parsedVariable
 }
 
 export const Main = () => {
@@ -47,7 +52,7 @@ export const Main = () => {
     for (let i = 0; i < idx; i++) {
       const newInstructions = instructions[i].variable_changes
       for (const [key, value] of Object.entries(newInstructions)) {
-        updateData(key, value, newData)
+        updateData(key, parseVariableValue(value), newData)
       }
     }
     setData(newData)

--- a/frontend/src/utils/executor.ts
+++ b/frontend/src/utils/executor.ts
@@ -1,9 +1,47 @@
 import axios from 'axios'
 
+interface boolValue {
+  type: 'bool'
+  value: boolean
+}
+
+interface numberValue {
+  type: 'int' | 'float'
+  value: number
+}
+
+interface strValue {
+  type: 'str'
+  value: string
+}
+
+interface dictValue {
+  type: 'dict'
+  value: Record<string, variableValue>
+}
+
+interface arrayValue {
+  type: 'list' | 'set' | 'tuple'
+  value: variableValue[]
+}
+
+interface arbitraryValue {
+  type: string
+  value: string
+}
+
+type variableValue =
+  | boolValue
+  | numberValue
+  | strValue
+  | dictValue
+  | arrayValue
+  | arbitraryValue
+
 interface instruction {
   line_number: number
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  variable_changes: Record<string, any>
+  variable_changes: Record<string, variableValue>
 }
 
 interface instructionRes {
@@ -18,13 +56,16 @@ const getInstructions = async (code: string): Promise<instructionRes> => {
       process.env.REACT_APP_EXECUTOR_ENDPOINT + '/execute',
       {
         code,
+        input: '',
       },
     )
+    const ret: instructionRes = {}
     const instructions = res.data?.data
-    if (instructions) return { instructions }
-    return {
-      errorMessage: res.data?.errorMessage || defaultErrorMessage,
+    if (instructions) ret.instructions = instructions
+    if (!instructions || res.data?.error) {
+      ret.errorMessage = res.data?.error || defaultErrorMessage
     }
+    return ret
   } catch (err) {
     return {
       errorMessage: defaultErrorMessage,
@@ -32,5 +73,38 @@ const getInstructions = async (code: string): Promise<instructionRes> => {
   }
 }
 
-export { getInstructions }
-export type { instruction }
+// This cannot be defined simply as one type, because Typescript has issues
+// with circular references.
+type parsedVariablePrimitive = boolean | number | string
+type parsedVariableArray = Array<parsedVariable>
+type parsedVariableRecord = { [key: string]: parsedVariable }
+type parsedVariable =
+  | parsedVariablePrimitive
+  | parsedVariableArray
+  | parsedVariableRecord
+
+// parses the data returned from executor into a string or number
+const parseVariableValue = (value: variableValue): parsedVariable => {
+  if (typeof value.value === 'string') {
+    return value.value
+  }
+
+  if (value.type === 'dict') {
+    const dict: parsedVariableRecord = {}
+    for (const key in value.value) {
+      dict[key] = parseVariableValue(value.value[key])
+    }
+    return dict
+  }
+
+  if (value.type === 'list' || value.type === 'set' || value.type === 'tuple') {
+    return value.value.map((element) => parseVariableValue(element))
+  }
+
+  // Type cast needed here because Typescript still thinks that
+  // value.value can be a variableValue[], even though it should not.
+  return value.value as number | boolean
+}
+
+export { getInstructions, parseVariableValue }
+export type { instruction, parsedVariable }

--- a/frontend/src/utils/executor.ts
+++ b/frontend/src/utils/executor.ts
@@ -40,7 +40,6 @@ type variableValue =
 
 interface instruction {
   line_number: number
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   variable_changes: Record<string, variableValue>
 }
 

--- a/services/executor/README.md
+++ b/services/executor/README.md
@@ -19,3 +19,111 @@ To deploy to the dev/prod environments (NOTE: **Prod deployment should not be ru
 ```bash
 pytest
 ```
+
+## Executor Input Format
+
+The executor takes in an object with the following properties:
+
+| Key   | Type   | Required | Description                                     |
+| ----- | ------ | -------- | ----------------------------------------------- |
+| code  | string | yes      | The code to be executed                         |
+| input | string | no       | Input to feed into stdin while executing `code` |
+
+```json
+{
+    "code": "a = 1\nb = int(input())\nc = a + b\nprint(c)"
+    "input": "2"
+}
+```
+
+## Executor Output Format
+
+The executor will return an object with the following properties
+
+| Key      | Type    | Description                                                                                  |
+| -------- | ------- | -------------------------------------------------------------------------------------------- |
+| executed | boolean | Whether the code was executed at all. Note that this is still true if a runtime error occurs |
+| output   | string  | Output captured from stdout                                                                  |
+| error    | string  | An error message if the input format is wrong, or there is a syntax / runtime error          |
+| data     | array   | Refer to the Variable Data section for more details                                          |
+
+## Variable Data
+
+Information about variables are returned in the form of variable changes in each line of code execution (to cut down size of returned data). The `data` array will contain elements of the following shape:
+
+| Key              | Type   | Description                                                                  |
+| ---------------- | ------ | ---------------------------------------------------------------------------- |
+| line_number      | number | The line number of the current code execution (first line if multiple lines) |
+| variable_changes | Object | -                                                                            |
+
+The `variable_changes` field will be an object, where keys are the name of the variable, and the values are objects containing `type` and `value` keys.
+
+The `type` will be a string representing the type of the variable, and the value is the value of the variable.
+
+| Type               | Value                                             |
+| ------------------ | ------------------------------------------------- |
+| bool               | boolean                                           |
+| int / float        | number                                            |
+| string             | string                                            |
+| dict               | object                                            |
+| list / set / tuple | array                                             |
+| any other types    | string (obtained from calling `object.__str__()`) |
+
+Here is an example of what the executor might return:
+
+```json
+{
+    "executed": True,
+    "output": "",
+    "data": [
+        {"line_number": 1, "variable_changes": {"a": {"type": "int", "value": 1}}},
+        {
+            "line_number": 2,
+            "variable_changes": {"b": {"type": "bool", "value": True}},
+        },
+        {
+            "line_number": 3,
+            "variable_changes": {"c": {"type": "str", "value": "string"}},
+        },
+        {
+            "line_number": 4,
+            "variable_changes": {"a": {"type": "float", "value": 1.5}},
+        },
+        {
+            "line_number": 5,
+            "variable_changes": {
+                "a": {
+                    "type": "list",
+                    "value": [
+                        {"type": "str", "value": "list"},
+                        {"type": "bool", "value": False},
+                        {"type": "int", "value": 123},
+                    ],
+                }
+            },
+        },
+        {
+            "line_number": 6,
+            "variable_changes": {
+                "a": {
+                    "type": "dict",
+                    "value": {"key": {"type": "str", "value": "value"}},
+                }
+            },
+        },
+        {
+            "line_number": 7,
+            "variable_changes": {
+                "a": {
+                    "type": "tuple",
+                    "value": [
+                        {"type": "int", "value": 1},
+                        {"type": "int", "value": 2},
+                        {"type": "int", "value": 3},
+                    ],
+                }
+            },
+        },
+    ],
+}
+```

--- a/services/executor/executor/main.py
+++ b/services/executor/executor/main.py
@@ -150,22 +150,16 @@ def execute(event):
                     "executed": False,
                     "data": debugger.data,
                     "output": output.getvalue(),
-                    "error": {"line_number": error.lineno, "message": str(error)},
+                    "error": str(error),
                 }
             )
         except Exception as error:
-            error_line_number = (
-                1 if len(debugger.data) == 0 else debugger.data[-1]["line_number"]
-            )
             return json_size_checker(
                 {
                     "executed": True,
                     "data": debugger.data,
                     "output": output.getvalue(),
-                    "error": {
-                        "line_number": error_line_number,
-                        "message": str(error),
-                    },
+                    "error": str(error),
                 }
             )
 

--- a/services/executor/executor/main.py
+++ b/services/executor/executor/main.py
@@ -107,15 +107,15 @@ class Debugger(bdb.Bdb):
 
 def execute(event):
     if not isinstance(event, dict):
-        return {"ok": False, "error": "Input event is not a dictionary"}
+        return {"executed": False, "error": "Input event is not a dictionary"}
 
     code = event.get("code")
     inp = event.get("input", "")
 
     if not isinstance(code, str):
-        return {"ok": False, "error": "Field 'code' must be a string"}
+        return {"executed": False, "error": "Field 'code' must be a string"}
     if not isinstance(inp, str):
-        return {"ok": False, "error": "Field 'input' must be empty or a string"}
+        return {"executed": False, "error": "Field 'input' must be empty or a string"}
 
     sys.stdin = StringIO(inp)
     output = StringIO()
@@ -124,11 +124,15 @@ def execute(event):
     with redirect_stdout(output):
         try:
             debugger.run(code, globals={}, locals={})
-            return {"ok": True, "data": debugger.data, "output": output.getvalue()}
+            return {
+                "executed": True,
+                "data": debugger.data,
+                "output": output.getvalue(),
+            }
         except SyntaxError as error:
             # Syntax errors will cause the code to not run at all (i.e. data and output are empty)
             return {
-                "ok": False,
+                "executed": False,
                 "data": debugger.data,
                 "output": output.getvalue(),
                 "error": {"line_number": error.lineno, "message": str(error)},
@@ -138,7 +142,7 @@ def execute(event):
                 1 if len(debugger.data) == 0 else debugger.data[-1]["line_number"]
             )
             return {
-                "ok": True,
+                "executed": True,
                 "data": debugger.data,
                 "output": output.getvalue(),
                 "error": {

--- a/services/executor/executor/main.py
+++ b/services/executor/executor/main.py
@@ -1,5 +1,9 @@
 import bdb
 import copy
+import sys
+from io import StringIO
+from contextlib import redirect_stdout
+
 
 class Debugger(bdb.Bdb):
     def __init__(self):
@@ -8,48 +12,142 @@ class Debugger(bdb.Bdb):
         self.data = []
         self.last_line_number = -1
         self.last_variables = {}
+        self.done = False
+
+    # This function takes in a dictionary of local variables and clones them
+    # into a predefined format that can be serialized into JSON data.
+    def clone_locals(self, locals_dict):
+        def convert_variable(value):
+            match value:
+                case bool():
+                    return {"type": "bool", "value": value}
+
+                case int():
+                    return {"type": "int", "value": value}
+
+                case float():
+                    return {"type": "float", "value": value}
+
+                case str():
+                    return {"type": "str", "value": value}
+
+                case dict():
+                    return {
+                        "type": "dict",
+                        "value": {
+                            child_key: convert_variable(child_value)
+                            for child_key, child_value in value.items()
+                        },
+                    }
+
+                case list():
+                    return {
+                        "type": "list",
+                        "value": [
+                            convert_variable(child_value) for child_value in value
+                        ],
+                    }
+
+                case set():
+                    return {
+                        "type": "set",
+                        "value": [
+                            convert_variable(child_value) for child_value in value
+                        ],
+                    }
+
+                case tuple():
+                    return {
+                        "type": "tuple",
+                        "value": [
+                            convert_variable(child_value) for child_value in value
+                        ],
+                    }
+
+                case _:
+                    return {"type": type(value).__name__, "value": value.__str__()}
+
+        return {key: convert_variable(value) for key, value in locals_dict.items()}
 
     def user_line(self, frame):
         if not self.is_tracing:
+            # First tiime this function is called (from the caller's frame), setup everything
             self.set_trace()
             self.is_tracing = True
             self.last_line_number = frame.f_lineno
             self.last_variables = copy.deepcopy(frame.f_locals)
+            return
+
+        if self.done:
+            # Code has finished executing, any further lines are from caller's frame and should be ignored
+            return
+
+        if "__name__" in frame.f_globals and frame.f_globals["__name__"] == "bdb":
+            # Code has finished executing, frame is caller's frame, hence we take frame.f_locals["locals"] instead
+            variables = self.clone_locals(frame.f_locals["locals"])
+            self.done = True
         else:
-            if '__name__' in frame.f_globals and frame.f_globals['__name__'] == 'bdb':
-                # final stack frame belonging to the caller
-                variables = copy.deepcopy(frame.f_locals['locals'])
-            else:
-                variables = copy.deepcopy(frame.f_locals)
-            variable_changes = {}
-            for var in variables:
-                if var in self.last_variables and self.last_variables[var] == variables[var]:
-                    continue
-                variable_changes[var] = variables[var]
+            variables = self.clone_locals(frame.f_locals)
 
-            self.data.append({
-                'line_number': self.last_line_number,
-                'variable_changes': variable_changes
-            })
-            self.last_line_number = frame.f_lineno
-            self.last_variables = variables
-            
+        variable_changes = {}
+        for var in variables:
+            if (
+                var in self.last_variables
+                and self.last_variables[var] == variables[var]
+            ):
+                continue
+            variable_changes[var] = variables[var]
 
-def execute(code):
+        self.data.append(
+            {"line_number": self.last_line_number, "variable_changes": variable_changes}
+        )
+        self.last_line_number = frame.f_lineno
+        self.last_variables = variables
+
+
+def execute(event):
+    if not isinstance(event, dict):
+        return {"ok": False, "error": "Input event is not a dictionary"}
+
+    code = event.get("code")
+    inp = event.get("input", "")
+
     if not isinstance(code, str):
-        return {
-            'ok': False,
-            'error': 'Code is not a string'
-        }
-    
+        return {"ok": False, "error": "Field 'code' must be a string"}
+    if not isinstance(inp, str):
+        return {"ok": False, "error": "Field 'input' must be empty or a string"}
+
+    sys.stdin = StringIO(inp)
+    output = StringIO()
     debugger = Debugger()
-    debugger.run(code, globals={}, locals={})
 
-    return {
-        'ok': True,
-        'data': debugger.data
-    }
+    with redirect_stdout(output):
+        try:
+            debugger.run(code, globals={}, locals={})
+            return {"ok": True, "data": debugger.data, "output": output.getvalue()}
+        except SyntaxError as error:
+            # Syntax errors will cause the code to not run at all (i.e. data and output are empty)
+            return {
+                "ok": False,
+                "data": debugger.data,
+                "output": output.getvalue(),
+                "error": {"line_number": error.lineno, "message": str(error)},
+            }
+        except Exception as error:
+            error_line_number = (
+                1 if len(debugger.data) == 0 else debugger.data[-1]["line_number"]
+            )
+            return {
+                "ok": True,
+                "data": debugger.data,
+                "output": output.getvalue(),
+                "error": {
+                    "line_number": error_line_number,
+                    "message": str(error),
+                },
+            }
 
-# handler function for AWS Lambda
-def handler(code, _context):
-    return execute(code)
+
+def handler(event, _context):
+    # handler function for AWS Lambda
+    return execute(event)

--- a/services/executor/tests/test_main.py
+++ b/services/executor/tests/test_main.py
@@ -153,3 +153,22 @@ def test_divide_by_zero_exception():
         "output": "",
         "error": {"line_number": 2, "message": "division by zero"},
     }
+
+
+def test_json_size_limit():
+    result = execute(
+        {
+            "code": dedent(
+                """\
+                    a = 0
+                    for i in range(10000):
+                        a += 1"""
+            )
+        }
+    )
+
+    print(result)
+    assert result == {
+        "executed": True,
+        "error": "Too much data was generated! Please don't overload our servers ):",
+    }

--- a/services/executor/tests/test_main.py
+++ b/services/executor/tests/test_main.py
@@ -1,22 +1,155 @@
 import pytest
+from textwrap import dedent
 from executor.main import execute
 
+
 def test_variable_declaration():
-    result = execute('a = 1\nb = 2\nc = 3')
+    result = execute(
+        {
+            "code": dedent(
+                """\
+            a = 1
+            b = True
+            c = 'string'
+            a = 1.5
+            a = ['list', False, 123]
+            a = {'key': 'value'}
+            a = (1, 2, 3)"""
+            )
+        }
+    )
+
     assert result == {
-        'ok': True,
-        'data': [
+        "ok": True,
+        "output": "",
+        "data": [
+            {"line_number": 1, "variable_changes": {"a": {"type": "int", "value": 1}}},
             {
-                'line_number': 1,
-                'variable_changes': {'a' : 1}
+                "line_number": 2,
+                "variable_changes": {"b": {"type": "bool", "value": True}},
             },
             {
-                'line_number': 2,
-                'variable_changes': {'b' : 2}
+                "line_number": 3,
+                "variable_changes": {"c": {"type": "str", "value": "string"}},
             },
             {
-                'line_number': 3,
-                'variable_changes': {'c' : 3}
+                "line_number": 4,
+                "variable_changes": {"a": {"type": "float", "value": 1.5}},
             },
-        ]
+            {
+                "line_number": 5,
+                "variable_changes": {
+                    "a": {
+                        "type": "list",
+                        "value": [
+                            {"type": "str", "value": "list"},
+                            {"type": "bool", "value": False},
+                            {"type": "int", "value": 123},
+                        ],
+                    }
+                },
+            },
+            {
+                "line_number": 6,
+                "variable_changes": {
+                    "a": {
+                        "type": "dict",
+                        "value": {"key": {"type": "str", "value": "value"}},
+                    }
+                },
+            },
+            {
+                "line_number": 7,
+                "variable_changes": {
+                    "a": {
+                        "type": "tuple",
+                        "value": [
+                            {"type": "int", "value": 1},
+                            {"type": "int", "value": 2},
+                            {"type": "int", "value": 3},
+                        ],
+                    }
+                },
+            },
+        ],
+    }
+
+
+def test_input_output():
+    result = execute(
+        {
+            "code": dedent(
+                """\
+                a = 1
+                b = int(input())
+                c = int(input())
+                d = a + b + c
+                print(f'Value of d is {d}')"""
+            ),
+            "input": dedent(
+                """\
+                2
+                3
+                Extra input is ignored"""
+            ),
+        }
+    )
+
+    print(result)
+    assert result == {
+        "ok": True,
+        "output": "Value of d is 6\n",
+        "data": [
+            {"line_number": 1, "variable_changes": {"a": {"type": "int", "value": 1}}},
+            {"line_number": 2, "variable_changes": {"b": {"type": "int", "value": 2}}},
+            {"line_number": 3, "variable_changes": {"c": {"type": "int", "value": 3}}},
+            {"line_number": 4, "variable_changes": {"d": {"type": "int", "value": 6}}},
+            {"line_number": 5, "variable_changes": {}},
+        ],
+    }
+
+
+def test_syntax_error():
+    result = execute(
+        {
+            "code": dedent(
+                """\
+            a = 123
+            b = '
+            c = 123"""
+            )
+        }
+    )
+
+    assert result == {
+        "ok": False,
+        "data": [],
+        "output": "",
+        "error": {
+            "line_number": 2,
+            "message": "unterminated string literal (detected at line 2) (<string>, line 2)",
+        },
+    }
+
+
+def test_divide_by_zero_exception():
+    result = execute(
+        {
+            "code": dedent(
+                """\
+            a = 1
+            b = a / 0
+            c = 1"""
+            )
+        }
+    )
+
+    assert result == {
+        "ok": True,
+        "data": [
+            {"line_number": 1, "variable_changes": {"a": {"type": "int", "value": 1}}},
+            {"line_number": 2, "variable_changes": {}},
+        ],
+        "output": "",
+        "error": {"line_number": 2, "message": "division by zero"},
     }

--- a/services/executor/tests/test_main.py
+++ b/services/executor/tests/test_main.py
@@ -125,10 +125,7 @@ def test_syntax_error():
         "executed": False,
         "data": [],
         "output": "",
-        "error": {
-            "line_number": 2,
-            "message": "unterminated string literal (detected at line 2) (<string>, line 2)",
-        },
+        "error": "unterminated string literal (detected at line 2) (<string>, line 2)",
     }
 
 
@@ -151,7 +148,7 @@ def test_divide_by_zero_exception():
             {"line_number": 2, "variable_changes": {}},
         ],
         "output": "",
-        "error": {"line_number": 2, "message": "division by zero"},
+        "error": "division by zero",
     }
 
 

--- a/services/executor/tests/test_main.py
+++ b/services/executor/tests/test_main.py
@@ -20,7 +20,7 @@ def test_variable_declaration():
     )
 
     assert result == {
-        "ok": True,
+        "executed": True,
         "output": "",
         "data": [
             {"line_number": 1, "variable_changes": {"a": {"type": "int", "value": 1}}},
@@ -97,7 +97,7 @@ def test_input_output():
 
     print(result)
     assert result == {
-        "ok": True,
+        "executed": True,
         "output": "Value of d is 6\n",
         "data": [
             {"line_number": 1, "variable_changes": {"a": {"type": "int", "value": 1}}},
@@ -122,7 +122,7 @@ def test_syntax_error():
     )
 
     assert result == {
-        "ok": False,
+        "executed": False,
         "data": [],
         "output": "",
         "error": {
@@ -145,7 +145,7 @@ def test_divide_by_zero_exception():
     )
 
     assert result == {
-        "ok": True,
+        "executed": True,
         "data": [
             {"line_number": 1, "variable_changes": {"a": {"type": "int", "value": 1}}},
             {"line_number": 2, "variable_changes": {}},


### PR DESCRIPTION
This PR upgrades the executor service so that it doesn't crash as much (e.g. when handling code that cannot be serialised to JSON). Tested with dev environment (https://feat-backend-improvement.d1fr5et3wgts3j.amplifyapp.com/).

Done:

- Added black as python code formatter

- Executor can read stdin and write to stdout

- All data should be serialisable now, either because they were originally serialisable (e.g. int, float, bool, str), by custom handling (e.g. dict, list, set, tuple), or simply by returning the object's __str__() value.
- Upgrade frontend to take in new response format
![Screenshot 2023-06-04 at 6 39 19 PM](https://github.com/huajun07/codesketcher/assets/30954848/49d3592a-e645-4bf9-83b5-f88084372135)

- Simple testcases for executor service

- Added error handling for syntax errors and runtime errors
![Screenshot 2023-06-04 at 6 59 14 PM](https://github.com/huajun07/codesketcher/assets/30954848/0eb54e83-2068-4a02-898a-6d786f06ccee)
![Screenshot 2023-06-04 at 6 59 37 PM](https://github.com/huajun07/codesketcher/assets/30954848/11160fb3-e052-4883-86c5-0860e0eca3c1)


- Update field "ok" to "executed" (response format from executor), to show whether the code was executed (either to completion or runtime error) or not (e.g. syntax errors, parameter errors etc.)

- Document the behaviour of the executor service so that we don't have to read the testcases to figure it out

- Add limits to JSON data sent back (to prevent executor lambda sending huge responses and using up all network outgress)

Future Work:

- Add stdin and stdout to frontend