### PR TITLE
Chore/deploy to prod on merge to main branch

### DIFF
--- a/.github/workflows/deploy-backend-prod.yml
+++ b/.github/workflows/deploy-backend-prod.yml
@@ -2,7 +2,7 @@ name: Deploy Backend (Prod)
 on:
   push:
     branches:
-      - chore/deploy-to-prod-on-merge
+      - main
 
 jobs:
   test:
@@ -12,8 +12,8 @@ jobs:
     needs: test
 
     env:
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_DEV_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_DEV_SECRET_ACCESS_KEY }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_PROD_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_PROD_SECRET_ACCESS_KEY }}
 
     steps:
       # checkout code
@@ -31,5 +31,5 @@ jobs:
         working-directory: ./backend
 
       # deploy backend
-      - run: npm run deploy:dev
+      - run: npm run deploy:prod
         working-directory: ./backend

--- a/.github/workflows/deploy-backend-prod.yml
+++ b/.github/workflows/deploy-backend-prod.yml
@@ -1,5 +1,8 @@
 name: Deploy Backend (Prod)
-on: workflow_dispatch
+on:
+  push:
+    branches:
+      - chore/deploy-to-prod-on-merge
 
 jobs:
   test:
@@ -9,8 +12,8 @@ jobs:
     needs: test
 
     env:
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_PROD_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_PROD_SECRET_ACCESS_KEY }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_DEV_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_DEV_SECRET_ACCESS_KEY }}
 
     steps:
       # checkout code
@@ -28,5 +31,5 @@ jobs:
         working-directory: ./backend
 
       # deploy backend
-      - run: npm run deploy:prod
+      - run: npm run deploy:dev
         working-directory: ./backend

--- a/.github/workflows/deploy-executor-prod.yml
+++ b/.github/workflows/deploy-executor-prod.yml
@@ -2,7 +2,7 @@ name: Deploy Executor (Prod)
 on:
   push:
     branches:
-      - chore/deploy-to-prod-on-merge
+      - main
 
 jobs:
   test:
@@ -12,8 +12,8 @@ jobs:
     needs: test
 
     env:
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_DEV_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_DEV_SECRET_ACCESS_KEY }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_PROD_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_PROD_SECRET_ACCESS_KEY }}
 
     steps:
       # checkout code
@@ -37,5 +37,5 @@ jobs:
           npm ci
 
       # deploy executor service
-      - run: npm run deploy:dev
+      - run: npm run deploy:prod
         working-directory: ./services/executor

--- a/.github/workflows/deploy-executor-prod.yml
+++ b/.github/workflows/deploy-executor-prod.yml
@@ -1,5 +1,8 @@
 name: Deploy Executor (Prod)
-on: workflow_dispatch
+on:
+  push:
+    branches:
+      - chore/deploy-to-prod-on-merge
 
 jobs:
   test:
@@ -9,8 +12,8 @@ jobs:
     needs: test
 
     env:
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_PROD_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_PROD_SECRET_ACCESS_KEY }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_DEV_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_DEV_SECRET_ACCESS_KEY }}
 
     steps:
       # checkout code
@@ -34,5 +37,5 @@ jobs:
           npm ci
 
       # deploy executor service
-      - run: npm run deploy:prod
+      - run: npm run deploy:dev
         working-directory: ./services/executor


### PR DESCRIPTION
Deployment to production should be automatic upon any updates (merge/commits) to main branch. This prevents user error (e.g. accidentally deploying the wrong branch to prod).

Tested by adding auto-deployment to dev on any updates to this branch in the first commit, deployments to [backend](https://github.com/huajun07/codesketcher/actions/runs/5173355169/jobs/9318553779) and [executor](https://github.com/huajun07/codesketcher/actions/runs/5173355168/jobs/9318552626) worked.

Then minimal changes to the code in the second commit to deploy to prod on any updates to main branch (I don't think this can be tested until we actually merge to main).