### PR TITLE
Fix/last line of function ignored

### DIFF
--- a/services/executor/tests/util.py
+++ b/services/executor/tests/util.py
@@ -1,0 +1,13 @@
+import re
+
+
+class MatchesRegex:
+    # This is a utility class to make testing easier.
+    # With this class, you can do:
+    # assert x == { "key": MatchesRegex("regex") }
+
+    def __init__(self, regex):
+        self.regex = re.compile(regex)
+
+    def __eq__(self, other):
+        return isinstance(other, str) and bool(self.regex.match(other))


### PR DESCRIPTION
This PR fixes this [issue](https://github.com/huajun07/codesketcher/issues/30).

```python
def func():
  a = 1
  b = 2

func()
```

The fix is to override the `user_return` function of the debugger, so that we can get the frame right after `b = 2` is executed but before the function returns and local variables are dropped.

Added the testcase above to executor, and tested on the [frontend](https://fix-last-line-of-function-ignored.d1fr5et3wgts3j.amplifyapp.com/) too.


![Screenshot 2023-06-07 at 12 44 23 PM](https://github.com/huajun07/codesketcher/assets/30954848/bbc7d9f4-3e10-4530-b245-d7c57179203f)
