### PR TITLE
Fix/timeout error handling

### DIFF
--- a/backend/src/aws/lambdaClient.ts
+++ b/backend/src/aws/lambdaClient.ts
@@ -1,0 +1,20 @@
+import config from '../config'
+import { InvokeCommand, Lambda } from '@aws-sdk/client-lambda'
+
+class Client {
+	lambdaClient = new Lambda({ region: config.get('executorRegion') })
+
+	async execute(functionName: string, payload: Record<string, unknown>) {
+		const command = new InvokeCommand({
+			FunctionName: functionName,
+			Payload: Buffer.from(JSON.stringify(payload)),
+		})
+		const { Payload } = await this.lambdaClient.send(command)
+		if (Payload === undefined) return null
+		return JSON.parse(Buffer.from(Payload).toString())
+	}
+}
+
+const client = new Client()
+
+export default client

--- a/backend/src/execute/execute.service.ts
+++ b/backend/src/execute/execute.service.ts
@@ -1,20 +1,32 @@
-import { InvokeCommand, Lambda } from '@aws-sdk/client-lambda'
 import config from '../config'
-
-const client = new Lambda({ region: config.get('executorRegion') })
+import logger from '../logger'
+import client from '../aws/lambdaClient'
 
 export default async function execute(payload: {
 	code: string
-	input: string | undefined
+	input?: string
 }) {
-	const command = new InvokeCommand({
-		FunctionName: config.get('executorName'),
-		Payload: Buffer.from(JSON.stringify(payload)),
-	})
-	const { Payload } = await client.send(command)
-	if (Payload === undefined) {
-		return null
+	const result = await client.execute(config.get('executorName'), payload)
+	if ('errorMessage' in result) {
+		// detect if AWS Lambda threw an error
+		const errorMessage = result.errorMessage as string
+		if (new RegExp('Task timed out after [.0-9]* seconds').test(errorMessage)) {
+			return {
+				executed: true,
+				error: 'Execution timed out (code executed for >1 second)',
+			}
+		}
+
+		// if the error is not a timeout, then likely something went wrong
+		// that requires investigation and fixing
+		logger.error(
+			{ awsLambdaError: result },
+			'Unexpected error occured during executor lambda invocation'
+		)
+		return {
+			executed: false,
+			error: 'An unexpected error has occured',
+		}
 	}
-	const result = JSON.parse(Buffer.from(Payload).toString())
 	return result
 }

--- a/backend/src/execute/execute.test.ts
+++ b/backend/src/execute/execute.test.ts
@@ -1,4 +1,40 @@
-test('test', () => {
-	// Mock test so that 'npm run test' passes
-	expect(1).toBe(1)
+import execute from './execute.service'
+import client from '../aws/lambdaClient'
+import logger from '../logger'
+
+jest.mock('../aws/lambdaClient')
+const mockedClient = client as jest.Mocked<typeof client>
+
+jest.mock('../logger')
+const mockedLogger = logger as jest.Mocked<typeof logger>
+
+afterEach(() => {
+	jest.clearAllMocks()
+})
+
+describe('execute service', () => {
+	it('should catch lambda timeouts and return an appropriate error message', async () => {
+		mockedClient.execute.mockResolvedValue({
+			errorMessage: 'timestamp request-id Task timed out after 1.01 seconds',
+		})
+		const result = await execute({
+			code: 'for i in range(1000000000):\n\tpass',
+		})
+		expect(result).toStrictEqual({
+			executed: true,
+			error: 'Execution timed out (code executed for >1 second)',
+		})
+	})
+
+	it('should catch unexpected lambda errors and return an appropriate error message', async () => {
+		mockedClient.execute.mockResolvedValue({
+			errorMessage: 'Unhandled error message',
+		})
+		const result = await execute({ code: '' })
+		expect(result).toStrictEqual({
+			executed: false,
+			error: 'An unexpected error has occured',
+		})
+		expect(mockedLogger.error).toBeCalled()
+	})
 })


### PR DESCRIPTION
This PR fixes this [issue](https://github.com/huajun07/codesketcher/issues/29).

Fix is to check for Lambda timeouts during invocation when called from the API server, and to return our own error instead of AWS's error.

Tested by adding unit tests. Tested with frontend manually too.

![Screenshot 2023-06-07 at 2 10 45 PM](https://github.com/huajun07/codesketcher/assets/30954848/12fadca7-6ffb-4f5e-8e28-12a1e29b5bb2)
