### PR TITLE
Feat/variable scope

### DIFF
--- a/frontend/src/pages/Main/Main.tsx
+++ b/frontend/src/pages/Main/Main.tsx
@@ -50,7 +50,13 @@ export const Main = () => {
   const setDataIdx = (idx: number) => {
     const newData: dataVal[] = []
     for (let i = 0; i < idx; i++) {
-      const newInstructions = instructions[i].variable_changes
+      // local_variable_changes and global_variable_changes will be merged for now,
+      // so that the frontend retains the same behaviour. Will be changed once we decide
+      // how to deal with function scopes in the frontend
+      const newInstructions = {
+        ...instructions[i].local_variable_changes,
+        ...instructions[i].global_variable_changes,
+      }
       for (const [key, value] of Object.entries(newInstructions)) {
         updateData(key, parseVariableValue(value), newData)
       }

--- a/frontend/src/utils/executor.ts
+++ b/frontend/src/utils/executor.ts
@@ -40,7 +40,9 @@ type variableValue =
 
 interface instruction {
   line_number: number
-  variable_changes: Record<string, variableValue>
+  function_scope: string[]
+  local_variable_changes: Record<string, variableValue>
+  global_variable_changes: Record<string, variableValue>
 }
 
 interface instructionRes {

--- a/services/executor/README.md
+++ b/services/executor/README.md
@@ -51,12 +51,14 @@ The executor will return an object with the following properties
 
 Information about variables are returned in the form of variable changes in each line of code execution (to cut down size of returned data). The `data` array will contain elements of the following shape:
 
-| Key              | Type   | Description                                                                  |
-| ---------------- | ------ | ---------------------------------------------------------------------------- |
-| line_number      | number | The line number of the current code execution (first line if multiple lines) |
-| variable_changes | Object | -                                                                            |
+| Key                     | Type     | Description                                                                                                            |
+| ----------------------- | -------- | ---------------------------------------------------------------------------------------------------------------------- |
+| line_number             | number   | The line number of the current code execution (first line if multiple lines)                                           |
+| function_scope          | string[] | An array of function names, representing the call stack (current function is last element). Empty if not in a function |
+| local_variable_changes  | Object   | -                                                                                                                      |
+| global_variable_changes | Object   | -                                                                                                                      |
 
-The `variable_changes` field will be an object, where keys are the name of the variable, and the values are objects containing `type` and `value` keys.
+The `local_variable_changes` and `global_variable_changes` field will be an object, where keys are the name of the variable, and the values are objects containing `type` and `value` keys.
 
 The `type` will be a string representing the type of the variable, and the value is the value of the variable.
 
@@ -73,57 +75,74 @@ Here is an example of what the executor might return:
 
 ```json
 {
-    "executed": True,
-    "output": "",
-    "data": [
-        {"line_number": 1, "variable_changes": {"a": {"type": "int", "value": 1}}},
-        {
-            "line_number": 2,
-            "variable_changes": {"b": {"type": "bool", "value": True}},
-        },
-        {
-            "line_number": 3,
-            "variable_changes": {"c": {"type": "str", "value": "string"}},
-        },
-        {
-            "line_number": 4,
-            "variable_changes": {"a": {"type": "float", "value": 1.5}},
-        },
-        {
-            "line_number": 5,
-            "variable_changes": {
-                "a": {
-                    "type": "list",
-                    "value": [
-                        {"type": "str", "value": "list"},
-                        {"type": "bool", "value": False},
-                        {"type": "int", "value": 123},
-                    ],
-                }
+        "executed": True,
+        "data": [
+            {
+                "line_number": 1,
+                "local_variable_changes": {"a": {"type": "int", "value": 1}},
+                "global_variable_changes": {},
+                "function_scope": [],
             },
-        },
-        {
-            "line_number": 6,
-            "variable_changes": {
-                "a": {
-                    "type": "dict",
-                    "value": {"key": {"type": "str", "value": "value"}},
-                }
+            {
+                "line_number": 2,
+                "local_variable_changes": {"b": {"type": "bool", "value": True}},
+                "global_variable_changes": {},
+                "function_scope": [],
             },
-        },
-        {
-            "line_number": 7,
-            "variable_changes": {
-                "a": {
-                    "type": "tuple",
-                    "value": [
-                        {"type": "int", "value": 1},
-                        {"type": "int", "value": 2},
-                        {"type": "int", "value": 3},
-                    ],
-                }
+            {
+                "line_number": 3,
+                "local_variable_changes": {"c": {"type": "str", "value": "string"}},
+                "global_variable_changes": {},
+                "function_scope": [],
             },
-        },
-    ],
-}
+            {
+                "line_number": 4,
+                "local_variable_changes": {"a": {"type": "float", "value": 1.5}},
+                "global_variable_changes": {},
+                "function_scope": [],
+            },
+            {
+                "line_number": 5,
+                "local_variable_changes": {
+                    "a": {
+                        "type": "list",
+                        "value": [
+                            {"type": "str", "value": "list"},
+                            {"type": "bool", "value": False},
+                            {"type": "int", "value": 123},
+                        ],
+                    }
+                },
+                "global_variable_changes": {},
+                "function_scope": [],
+            },
+            {
+                "line_number": 6,
+                "local_variable_changes": {
+                    "a": {
+                        "type": "dict",
+                        "value": {"key": {"type": "str", "value": "value"}},
+                    }
+                },
+                "global_variable_changes": {},
+                "function_scope": [],
+            },
+            {
+                "line_number": 7,
+                "local_variable_changes": {
+                    "a": {
+                        "type": "tuple",
+                        "value": [
+                            {"type": "int", "value": 1},
+                            {"type": "int", "value": 2},
+                            {"type": "int", "value": 3},
+                        ],
+                    }
+                },
+                "global_variable_changes": {},
+                "function_scope": [],
+            },
+        ],
+        "output": "",
+    }
 ```

--- a/services/executor/executor/main.py
+++ b/services/executor/executor/main.py
@@ -14,7 +14,7 @@ class Debugger(bdb.Bdb):
         self.done = False
         self.previous_line_number = -1
         self.data = []
-        self.previous_function_scope = []
+        self.previous_function_scope = []  # e.g. ["f1", "f2"]. Empty if not in function
         self.previous_local_variables_stack = [{}]
         self.previous_global_variables = {}
         self.current_local_variables = {}

--- a/services/executor/executor/main.py
+++ b/services/executor/executor/main.py
@@ -35,7 +35,7 @@ class Debugger(bdb.Bdb):
                     }
 
                 case list() | set() | tuple():
-                    value = map(convert_variable, variable)
+                    value = list(map(convert_variable, variable))
 
                 case _:
                     value = variable.__str__()

--- a/services/executor/executor/main.py
+++ b/services/executor/executor/main.py
@@ -39,7 +39,7 @@ class Debugger(bdb.Bdb):
 
                 case _:
                     value = variable.__str__()
-            return {"type": type(value).__name__, "value": value}
+            return {"type": type(variable).__name__, "value": value}
 
         return {key: convert_variable(value) for key, value in variables_dict.items()}
 

--- a/services/executor/executor/main.py
+++ b/services/executor/executor/main.py
@@ -117,7 +117,11 @@ class Debugger(bdb.Bdb):
             }
         )
 
-        self.previous_function_scope = self.get_scope(frame)
+        current_scope = self.get_scope(frame)
+        while len(current_scope) + 1 > len(self.previous_local_variables_stack):
+            self.previous_local_variables_stack.append({})
+
+        self.previous_function_scope = current_scope
         self.previous_line_number = frame.f_lineno
         self.previous_local_variables_stack[-1] = self.current_local_variables
         self.previous_global_variables = self.current_global_variables

--- a/services/executor/executor/main.py
+++ b/services/executor/executor/main.py
@@ -9,12 +9,16 @@ from contextlib import redirect_stdout
 class Debugger(bdb.Bdb):
     def __init__(self):
         super().__init__()
+        self.root_frame = None
         self.is_tracing = False
-        self.data = []
-        self.last_line_number = -1
-        self.last_variables = {}
-        self.current_variables = {}
         self.done = False
+        self.previous_line_number = -1
+        self.data = []
+        self.previous_function_scope = []
+        self.previous_local_variables_stack = [{}]
+        self.previous_global_variables = {}
+        self.current_local_variables = {}
+        self.current_global_variables = {}
 
     # This function takes in a dictionary of variables and clones them
     # into a predefined format that can be serialized into JSON data.
@@ -39,46 +43,86 @@ class Debugger(bdb.Bdb):
 
         return {key: convert_variable(value) for key, value in variables_dict.items()}
 
+    def get_scope(self, frame):
+        if frame == self.root_frame or frame == self.root_frame.f_back:
+            return []
+        return self.get_scope(frame.f_back) + [frame.f_code.co_name]
+
     def user_return(self, frame, return_value):
         # Since local variables are dropped upon returning, we need to capture them here
-        self.current_variables |= frame.f_locals
+        if len(self.get_scope(frame)) == len(self.previous_function_scope):
+            self.current_local_variables |= frame.f_locals
+            self.current_global_variables |= frame.f_globals
 
     def user_line(self, frame):
         if not self.is_tracing:
             # First tiime this function is called (from the caller's frame), setup everything
             self.set_trace()
+            self.root_frame = frame
             self.is_tracing = True
-            self.last_line_number = frame.f_lineno
-            self.last_variables = copy.deepcopy(frame.f_locals)
+            self.previous_line_number = frame.f_lineno
             return
 
         if self.done:
             # Code has finished executing, any further lines are from caller's frame and should be ignored
             return
 
-        if "__name__" in frame.f_globals and frame.f_globals["__name__"] == "bdb":
-            # Code has finished executing, frame is caller's frame, hence we take frame.f_locals["locals"] instead
-            self.current_variables |= frame.f_locals["locals"]
-            self.done = True
-        else:
-            self.current_variables |= frame.f_locals
-        variables = self.clone_locals(self.current_variables)
-        self.current_variables = {}
+        current_scope = self.previous_function_scope
+        while len(current_scope) + 1 < len(self.previous_local_variables_stack):
+            self.previous_local_variables_stack.pop()
+        while len(current_scope) + 1 > len(self.previous_local_variables_stack):
+            self.previous_local_variables_stack.append({})
 
-        variable_changes = {}
-        for var in variables:
+        if len(self.previous_function_scope) <= len(self.get_scope(frame)):
+            if "__name__" in frame.f_globals and frame.f_globals["__name__"] == "bdb":
+                # Code has finished executing, frame is caller's frame, hence we take frame.f_locals["locals"] instead
+                self.current_local_variables |= frame.f_locals["locals"]
+                self.current_global_variables |= frame.f_locals["globals"]
+                self.done = True
+            else:
+                self.current_local_variables |= frame.f_locals
+                self.current_global_variables |= frame.f_globals
+        self.current_global_variables.pop("__builtins__")
+
+        local_variables_info = self.clone_variables(self.current_local_variables)
+        global_variables_info = self.clone_variables(self.current_global_variables)
+
+        local_variable_changes = {}
+        global_variable_changes = {}
+
+        previous_local_variables = self.previous_local_variables_stack[-1]
+        for var in self.current_local_variables:
             if (
-                var in self.last_variables
-                and self.last_variables[var] == variables[var]
+                var in previous_local_variables
+                and previous_local_variables[var] == self.current_local_variables[var]
             ):
                 continue
-            variable_changes[var] = variables[var]
+            local_variable_changes[var] = local_variables_info[var]
+
+        for var in self.current_global_variables:
+            if (
+                var in self.previous_global_variables
+                and self.previous_global_variables[var]
+                == self.current_global_variables[var]
+            ):
+                continue
+            global_variable_changes[var] = global_variables_info[var]
 
         self.data.append(
-            {"line_number": self.last_line_number, "variable_changes": variable_changes}
+            {
+                "line_number": self.previous_line_number,
+                "local_variable_changes": local_variable_changes,
+                "global_variable_changes": global_variable_changes,
+                "function_scope": self.previous_function_scope,
+            }
         )
-        self.last_line_number = frame.f_lineno
-        self.last_variables = variables
+
+        self.previous_function_scope = self.get_scope(frame)
+        self.previous_line_number = frame.f_lineno
+        self.previous_local_variables_stack[-1] = self.current_local_variables
+        self.previous_global_variables = self.current_global_variables
+        self.current_local_variables = {}
+        self.current_global_variables = {}
 
 
 def json_size_checker(return_data):

--- a/services/executor/executor/main.py
+++ b/services/executor/executor/main.py
@@ -8,7 +8,8 @@ from contextlib import redirect_stdout
 
 class Debugger(bdb.Bdb):
     def __init__(self):
-        super().__init__()
+        # Skip modules added in AWS Lambda's runtime
+        super().__init__(skip=["awslambdaric.bootstrap"])
         self.root_frame = None
         self.is_tracing = False
         self.done = False

--- a/services/executor/tests/test_main.py
+++ b/services/executor/tests/test_main.py
@@ -22,24 +22,34 @@ def test_variable_declaration():
 
     assert result == {
         "executed": True,
-        "output": "",
         "data": [
-            {"line_number": 1, "variable_changes": {"a": {"type": "int", "value": 1}}},
+            {
+                "line_number": 1,
+                "local_variable_changes": {"a": {"type": "int", "value": 1}},
+                "global_variable_changes": {},
+                "function_scope": [],
+            },
             {
                 "line_number": 2,
-                "variable_changes": {"b": {"type": "bool", "value": True}},
+                "local_variable_changes": {"b": {"type": "bool", "value": True}},
+                "global_variable_changes": {},
+                "function_scope": [],
             },
             {
                 "line_number": 3,
-                "variable_changes": {"c": {"type": "str", "value": "string"}},
+                "local_variable_changes": {"c": {"type": "str", "value": "string"}},
+                "global_variable_changes": {},
+                "function_scope": [],
             },
             {
                 "line_number": 4,
-                "variable_changes": {"a": {"type": "float", "value": 1.5}},
+                "local_variable_changes": {"a": {"type": "float", "value": 1.5}},
+                "global_variable_changes": {},
+                "function_scope": [],
             },
             {
                 "line_number": 5,
-                "variable_changes": {
+                "local_variable_changes": {
                     "a": {
                         "type": "list",
                         "value": [
@@ -49,19 +59,23 @@ def test_variable_declaration():
                         ],
                     }
                 },
+                "global_variable_changes": {},
+                "function_scope": [],
             },
             {
                 "line_number": 6,
-                "variable_changes": {
+                "local_variable_changes": {
                     "a": {
                         "type": "dict",
                         "value": {"key": {"type": "str", "value": "value"}},
                     }
                 },
+                "global_variable_changes": {},
+                "function_scope": [],
             },
             {
                 "line_number": 7,
-                "variable_changes": {
+                "local_variable_changes": {
                     "a": {
                         "type": "tuple",
                         "value": [
@@ -71,8 +85,11 @@ def test_variable_declaration():
                         ],
                     }
                 },
+                "global_variable_changes": {},
+                "function_scope": [],
             },
         ],
+        "output": "",
     }
 
 
@@ -96,17 +113,41 @@ def test_input_output():
         }
     )
 
-    print(result)
     assert result == {
         "executed": True,
-        "output": "Value of d is 6\n",
         "data": [
-            {"line_number": 1, "variable_changes": {"a": {"type": "int", "value": 1}}},
-            {"line_number": 2, "variable_changes": {"b": {"type": "int", "value": 2}}},
-            {"line_number": 3, "variable_changes": {"c": {"type": "int", "value": 3}}},
-            {"line_number": 4, "variable_changes": {"d": {"type": "int", "value": 6}}},
-            {"line_number": 5, "variable_changes": {}},
+            {
+                "line_number": 1,
+                "local_variable_changes": {"a": {"type": "int", "value": 1}},
+                "global_variable_changes": {},
+                "function_scope": [],
+            },
+            {
+                "line_number": 2,
+                "local_variable_changes": {"b": {"type": "int", "value": 2}},
+                "global_variable_changes": {},
+                "function_scope": [],
+            },
+            {
+                "line_number": 3,
+                "local_variable_changes": {"c": {"type": "int", "value": 3}},
+                "global_variable_changes": {},
+                "function_scope": [],
+            },
+            {
+                "line_number": 4,
+                "local_variable_changes": {"d": {"type": "int", "value": 6}},
+                "global_variable_changes": {},
+                "function_scope": [],
+            },
+            {
+                "line_number": 5,
+                "local_variable_changes": {},
+                "global_variable_changes": {},
+                "function_scope": [],
+            },
         ],
+        "output": "Value of d is 6\n",
     }
 
 
@@ -145,8 +186,18 @@ def test_divide_by_zero_exception():
     assert result == {
         "executed": True,
         "data": [
-            {"line_number": 1, "variable_changes": {"a": {"type": "int", "value": 1}}},
-            {"line_number": 2, "variable_changes": {}},
+            {
+                "line_number": 1,
+                "local_variable_changes": {"a": {"type": "int", "value": 1}},
+                "global_variable_changes": {},
+                "function_scope": [],
+            },
+            {
+                "line_number": 2,
+                "local_variable_changes": {},
+                "global_variable_changes": {},
+                "function_scope": [],
+            },
         ],
         "output": "",
         "error": "division by zero",
@@ -190,24 +241,32 @@ def test_function_without_return_statement():
         "data": [
             {
                 "line_number": 1,
-                "variable_changes": {
+                "local_variable_changes": {
                     "func": {
                         "type": "function",
                         "value": MatchesRegex("<function func at 0x[a-z0-9_]*>"),
                     }
                 },
+                "global_variable_changes": {},
+                "function_scope": [],
             },
-            {"line_number": 5, "variable_changes": {}},
-            {"line_number": 2, "variable_changes": {"a": {"type": "int", "value": 1}}},
+            {
+                "line_number": 5,
+                "local_variable_changes": {},
+                "global_variable_changes": {},
+                "function_scope": [],
+            },
+            {
+                "line_number": 2,
+                "local_variable_changes": {"a": {"type": "int", "value": 1}},
+                "global_variable_changes": {},
+                "function_scope": ["func"],
+            },
             {
                 "line_number": 3,
-                "variable_changes": {
-                    "b": {"type": "int", "value": 2},
-                    "func": {
-                        "type": "function",
-                        "value": MatchesRegex("<function func at 0x[a-z0-9_]*>"),
-                    },
-                },
+                "local_variable_changes": {"b": {"type": "int", "value": 2}},
+                "global_variable_changes": {},
+                "function_scope": ["func"],
             },
         ],
         "output": "",

--- a/services/executor/tests/test_main.py
+++ b/services/executor/tests/test_main.py
@@ -244,7 +244,7 @@ def test_function_without_return_statement():
                 "local_variable_changes": {
                     "func": {
                         "type": "function",
-                        "value": MatchesRegex("<function func at 0x[a-z0-9_]*>"),
+                        "value": MatchesRegex("<function func at 0x[0-9a-f]*>"),
                     }
                 },
                 "global_variable_changes": {},

--- a/services/executor/tests/test_main.py
+++ b/services/executor/tests/test_main.py
@@ -271,3 +271,221 @@ def test_function_without_return_statement():
         ],
         "output": "",
     }
+
+
+def test_nested_functions():
+    result = execute(
+        {
+            "code": dedent(
+                """\
+                    def func1():
+                        a = 1
+                        def func2():
+                            b = 2
+                            a = 2
+                            def func3():
+                                a = 3
+                            func3()
+                            a = 3
+                        func2()
+                        a = 1
+                    
+                    func1()"""
+            )
+        }
+    )
+
+    assert result == {
+        "executed": True,
+        "data": [
+            {
+                "line_number": 1,
+                "local_variable_changes": {
+                    "func1": {
+                        "type": "function",
+                        "value": MatchesRegex("<function func1 at 0x[0-9a-f]*>"),
+                    }
+                },
+                "global_variable_changes": {},
+                "function_scope": [],
+            },
+            {
+                "line_number": 13,
+                "local_variable_changes": {},
+                "global_variable_changes": {},
+                "function_scope": [],
+            },
+            {
+                "line_number": 2,
+                "local_variable_changes": {"a": {"type": "int", "value": 1}},
+                "global_variable_changes": {},
+                "function_scope": ["func1"],
+            },
+            {
+                "line_number": 3,
+                "local_variable_changes": {
+                    "func2": {
+                        "type": "function",
+                        "value": MatchesRegex(
+                            "<function func1.<locals>.func2 at 0x[0-9a-f]*>"
+                        ),
+                    }
+                },
+                "global_variable_changes": {},
+                "function_scope": ["func1"],
+            },
+            {
+                "line_number": 10,
+                "local_variable_changes": {},
+                "global_variable_changes": {},
+                "function_scope": ["func1"],
+            },
+            {
+                "line_number": 4,
+                "local_variable_changes": {"b": {"type": "int", "value": 2}},
+                "global_variable_changes": {},
+                "function_scope": ["func1", "func2"],
+            },
+            {
+                "line_number": 5,
+                "local_variable_changes": {"a": {"type": "int", "value": 2}},
+                "global_variable_changes": {},
+                "function_scope": ["func1", "func2"],
+            },
+            {
+                "line_number": 6,
+                "local_variable_changes": {
+                    "func3": {
+                        "type": "function",
+                        "value": MatchesRegex(
+                            "<function func1.<locals>.func2.<locals>.func3 at 0x[0-9a-f]*>"
+                        ),
+                    }
+                },
+                "global_variable_changes": {},
+                "function_scope": ["func1", "func2"],
+            },
+            {
+                "line_number": 8,
+                "local_variable_changes": {},
+                "global_variable_changes": {},
+                "function_scope": ["func1", "func2"],
+            },
+            {
+                "line_number": 7,
+                "local_variable_changes": {"a": {"type": "int", "value": 3}},
+                "global_variable_changes": {},
+                "function_scope": ["func1", "func2", "func3"],
+            },
+            {
+                "line_number": 9,
+                "local_variable_changes": {
+                    "a": {"type": "int", "value": 3},
+                },
+                "global_variable_changes": {},
+                "function_scope": ["func1", "func2"],
+            },
+            {
+                "line_number": 11,
+                "local_variable_changes": {},
+                "global_variable_changes": {},
+                "function_scope": ["func1"],
+            },
+        ],
+        "output": "",
+    }
+
+
+def test_global_variables():
+    result = execute(
+        {
+            "code": dedent(
+                """\
+                    a = 1
+                    b = 1
+                    def func1():
+                        global a
+                        a = 2
+                        def func2():
+                            global b
+                            b = 2
+                            a = 3
+                        func2()
+                    
+                    func1()"""
+            )
+        }
+    )
+
+    assert result == {
+        "executed": True,
+        "data": [
+            {
+                "line_number": 1,
+                "local_variable_changes": {},
+                "global_variable_changes": {"a": {"type": "int", "value": 1}},
+                "function_scope": [],
+            },
+            {
+                "line_number": 2,
+                "local_variable_changes": {},
+                "global_variable_changes": {"b": {"type": "int", "value": 1}},
+                "function_scope": [],
+            },
+            {
+                "line_number": 3,
+                "local_variable_changes": {
+                    "func1": {
+                        "type": "function",
+                        "value": MatchesRegex("<function func1 at 0x[0-9a-f]*>"),
+                    }
+                },
+                "global_variable_changes": {},
+                "function_scope": [],
+            },
+            {
+                "line_number": 12,
+                "local_variable_changes": {},
+                "global_variable_changes": {},
+                "function_scope": [],
+            },
+            {
+                "line_number": 5,
+                "local_variable_changes": {},
+                "global_variable_changes": {"a": {"type": "int", "value": 2}},
+                "function_scope": ["func1"],
+            },
+            {
+                "line_number": 6,
+                "local_variable_changes": {
+                    "func2": {
+                        "type": "function",
+                        "value": MatchesRegex(
+                            "<function func1.<locals>.func2 at 0x[0-9a-f]*>"
+                        ),
+                    }
+                },
+                "global_variable_changes": {},
+                "function_scope": ["func1"],
+            },
+            {
+                "line_number": 10,
+                "local_variable_changes": {},
+                "global_variable_changes": {},
+                "function_scope": ["func1"],
+            },
+            {
+                "line_number": 8,
+                "local_variable_changes": {},
+                "global_variable_changes": {"b": {"type": "int", "value": 2}},
+                "function_scope": ["func1", "func2"],
+            },
+            {
+                "line_number": 9,
+                "local_variable_changes": {"a": {"type": "int", "value": 3}},
+                "global_variable_changes": {},
+                "function_scope": ["func1", "func2"],
+            },
+        ],
+        "output": "",
+    }


### PR DESCRIPTION
This PR implements this [feature](https://github.com/huajun07/codesketcher/issues/32) on the backend.

Implementation details can be found in the README of services/executor. (TL;DR splits `variable_changes` field into `local_variable_changes` and `global_variable_changes`, and adds a `function_scope` field).

Tested by adding testcases to executor service. Frontend can be tested [here](https://feat-variable-scope.d1fr5et3wgts3j.amplifyapp.com/).

Note that the frontend simply merges the `local_variable_changes` and `global_variable_changes` for now, which can lead to bugs like this. This is something to keep in mind when we implement the frontend part of this feature.
![Screenshot 2023-06-08 at 11 24 50 PM](https://github.com/huajun07/codesketcher/assets/30954848/581c5a27-b14b-4096-9f78-cd583d7ca045)
(since `a` in the `f1` scope is not modified in the last line, we end up with `a = 2` instead of `a = 1` being displayed)