### PR TITLE
Fix: Update arrays and dictionaries values when mutated

### DIFF
--- a/services/executor/executor/main.py
+++ b/services/executor/executor/main.py
@@ -124,8 +124,10 @@ class Debugger(bdb.Bdb):
 
         self.previous_function_scope = current_scope
         self.previous_line_number = frame.f_lineno
-        self.previous_local_variables_stack[-1] = self.current_local_variables
-        self.previous_global_variables = self.current_global_variables
+        self.previous_local_variables_stack[-1] = copy.deepcopy(
+            self.current_local_variables
+        )
+        self.previous_global_variables = copy.deepcopy(self.current_global_variables)
         self.current_local_variables = {}
         self.current_global_variables = {}
 

--- a/services/executor/tests/test_main.py
+++ b/services/executor/tests/test_main.py
@@ -489,3 +489,127 @@ def test_global_variables():
         ],
         "output": "",
     }
+
+
+def test_array_mutation():
+    result = execute(
+        {
+            "code": dedent(
+                """\
+                    a = [1, [2, 3], 4]
+                    a[0] = 2
+                    a[1][0] = 3"""
+            )
+        }
+    )
+
+    assert result == {
+        "executed": True,
+        "data": [
+            {
+                "line_number": 1,
+                "local_variable_changes": {
+                    "a": {
+                        "type": "list",
+                        "value": [
+                            {"type": "int", "value": 1},
+                            {
+                                "type": "list",
+                                "value": [
+                                    {"type": "int", "value": 2},
+                                    {"type": "int", "value": 3},
+                                ],
+                            },
+                            {"type": "int", "value": 4},
+                        ],
+                    }
+                },
+                "global_variable_changes": {},
+                "function_scope": [],
+            },
+            {
+                "line_number": 2,
+                "local_variable_changes": {
+                    "a": {
+                        "type": "list",
+                        "value": [
+                            {"type": "int", "value": 2},
+                            {
+                                "type": "list",
+                                "value": [
+                                    {"type": "int", "value": 2},
+                                    {"type": "int", "value": 3},
+                                ],
+                            },
+                            {"type": "int", "value": 4},
+                        ],
+                    }
+                },
+                "global_variable_changes": {},
+                "function_scope": [],
+            },
+            {
+                "line_number": 3,
+                "local_variable_changes": {
+                    "a": {
+                        "type": "list",
+                        "value": [
+                            {"type": "int", "value": 2},
+                            {
+                                "type": "list",
+                                "value": [
+                                    {"type": "int", "value": 3},
+                                    {"type": "int", "value": 3},
+                                ],
+                            },
+                            {"type": "int", "value": 4},
+                        ],
+                    }
+                },
+                "global_variable_changes": {},
+                "function_scope": [],
+            },
+        ],
+        "output": "",
+    }
+
+
+def test_dict_mutation():
+    result = execute(
+        {
+            "code": dedent(
+                """\
+                    a = {'key': 123}
+                    a['key'] = 456"""
+            )
+        }
+    )
+
+    assert result == {
+        "executed": True,
+        "data": [
+            {
+                "line_number": 1,
+                "local_variable_changes": {
+                    "a": {
+                        "type": "dict",
+                        "value": {"key": {"type": "int", "value": 123}},
+                    }
+                },
+                "global_variable_changes": {},
+                "function_scope": [],
+            },
+            {
+                "line_number": 2,
+                "local_variable_changes": {
+                    "a": {
+                        "type": "dict",
+                        "value": {"key": {"type": "int", "value": 456}},
+                    }
+                },
+                "global_variable_changes": {},
+                "function_scope": [],
+            },
+        ],
+        "output": "",
+    }


### PR DESCRIPTION
This PR fixes this [issue](https://github.com/huajun07/codesketcher/issues/42). The bug is in the executor service, where the previous variables were stored by reference. Hence, they got modified when the next line runs, and became equal to the current variables.

The fix is to deep copy (with `copy.deepcopy`) the variables, so that the stored previous variables do not change.

Tested locally on the frontend. Testcases for array and dict have been added to the executor service.

![Screenshot 2023-06-18 at 7 02 54 PM](https://github.com/huajun07/codesketcher/assets/30954848/13c59000-3065-40e7-90c3-0ad01c35bc71)

![Screenshot 2023-06-18 at 7 03 21 PM](https://github.com/huajun07/codesketcher/assets/30954848/2e0d06b3-3d68-408b-8738-3825c3eb07d1)
