### PR TITLE
Add store to frontend to reduce code complexity

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -26,7 +26,8 @@
         "react-dom": "^18.2.0",
         "react-icons": "^4.8.0",
         "react-router-dom": "^6.11.2",
-        "react-scripts": "^5.0.1"
+        "react-scripts": "^5.0.1",
+        "zustand": "^4.3.8"
       },
       "devDependencies": {
         "@types/react-dom": "^18.2.4",
@@ -17726,6 +17727,14 @@
         }
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -18737,6 +18746,29 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "4.3.8",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.3.8.tgz",
+      "integrity": "sha512-4h28KCkHg5ii/wcFFJ5Fp+k1J3gJoasaIbppdgZFO4BPJnsNxL0mQXBSFgOgAdCdBj35aDTPvdAJReTMntFPGg==",
+      "dependencies": {
+        "use-sync-external-store": "1.2.0"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "immer": ">=9.0",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
       }
     }
   }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -30,7 +30,8 @@
     "react-dom": "^18.2.0",
     "react-icons": "^4.8.0",
     "react-router-dom": "^6.11.2",
-    "react-scripts": "^5.0.1"
+    "react-scripts": "^5.0.1",
+    "zustand": "^4.3.8"
   },
   "devDependencies": {
     "@types/react-dom": "^18.2.4",

--- a/frontend/src/components/ControlBar.tsx
+++ b/frontend/src/components/ControlBar.tsx
@@ -17,9 +17,9 @@ import {
   Text,
   useColorModeValue,
 } from '@chakra-ui/react'
+import useExecutionStore from 'stores/executionStore'
 
 interface ControlBarProps {
-  curIdx: number
   playing: boolean
   length: number
   curSpeed: number
@@ -28,25 +28,28 @@ interface ControlBarProps {
   setSpeed: (speed: number) => void
   togglePlaying: () => void
   setWasPlaying: (newVal: boolean) => void
-  setCurIdx: (idx: number) => void
   moveStep: (forward: boolean) => void
 }
 
 export const ControlBar = (props: ControlBarProps) => {
+  const { currentStep, setStep } = useExecutionStore((state) => ({
+    currentStep: state.currentStep,
+    setStep: state.setStep,
+  }))
   const buttonColor = useColorModeValue('#3182ce', '#90cdf4')
   return (
     <>
       <Flex flexDirection="column">
         <Box px="15px" paddingTop="10px">
           <Slider
-            value={props.curIdx}
+            value={currentStep}
             min={0}
             max={props.length}
             step={1}
             size="lg"
             focusThumbOnChange={false}
             isDisabled={props.disabled}
-            onChange={props.setCurIdx}
+            onChange={setStep}
             onChangeStart={
               props.playing
                 ? () => {
@@ -106,7 +109,7 @@ export const ControlBar = (props: ControlBarProps) => {
               background="none"
               size="lg"
               aria-label="Play/Pause"
-              isDisabled={props.disabled || props.curIdx === props.length}
+              isDisabled={props.disabled || currentStep === props.length}
               icon={
                 props.playing ? (
                   <FaPause color={buttonColor} />
@@ -132,11 +135,11 @@ export const ControlBar = (props: ControlBarProps) => {
             <NumberInput
               maxW="80px"
               mr="2rem"
-              value={props.curIdx}
+              value={currentStep}
               min={0}
               max={props.length}
               isDisabled={props.disabled}
-              onChange={(v) => props.setCurIdx(Number(v))}
+              onChange={(v) => setStep(Number(v))}
             >
               <NumberInputField />
               <NumberInputStepper>

--- a/frontend/src/components/DataTable.tsx
+++ b/frontend/src/components/DataTable.tsx
@@ -12,6 +12,7 @@ import {
   Text,
   useColorModeValue,
 } from '@chakra-ui/react'
+import useExecutionStore from 'stores/executionStore'
 
 import { parsedVariable } from 'utils/executor'
 
@@ -23,22 +24,14 @@ const RowData = (props: RowDataProps) => {
   return <Text>{JSON.stringify(props.val)}</Text>
 }
 
-interface dataVal {
-  name: string
-  value: parsedVariable
-}
-
-interface dataTableProps {
-  data: dataVal[]
-}
-
-export const DataTable = (props: dataTableProps) => {
+export const DataTable = () => {
+  const data = useExecutionStore((state) => state.data)
   const [filterVal, setFilterVal] = useState('')
   const columns = [
     { key: 'name', name: 'Name', resizable: true, frozen: true },
     { key: 'value', name: 'Value', resizable: true },
   ]
-  const rows = props.data.map((v) => {
+  const rows = data.map((v) => {
     return { name: v.name, value: <RowData val={v.value} /> }
   })
   return (

--- a/frontend/src/stores/executionStore.ts
+++ b/frontend/src/stores/executionStore.ts
@@ -1,0 +1,64 @@
+import { create } from 'zustand'
+
+import { instruction, parsedVariable, parseVariableValue } from 'utils/executor'
+
+interface dataVal {
+  name: string
+  value: parsedVariable
+}
+
+interface ExecutionState {
+  currentStep: number
+  setStep: (step: number) => void
+  instructions: instruction[]
+  setInstructions: (instructions: instruction[]) => void
+  data: dataVal[]
+  allVariableNames: string[]
+}
+
+const useExecutionStore = create<ExecutionState>((set, get) => ({
+  currentStep: 0,
+  setStep: (step: number) => {
+    const newData: dataVal[] = []
+    for (let i = 0; i < step; i++) {
+      // local_variable_changes and global_variable_changes will be merged for now,
+      // so that the frontend retains the same behaviour. Will be changed once we decide
+      // how to deal with function scopes in the frontend
+      const newInstruction = {
+        ...get().instructions[i].local_variable_changes,
+        ...get().instructions[i].global_variable_changes,
+      }
+      for (const [name, value] of Object.entries(newInstruction)) {
+        const idx = newData.findIndex((item) => item.name === name)
+        const newValue = { name, value: parseVariableValue(value) }
+        if (idx !== -1) newData[idx] = newValue
+        else newData.push(newValue)
+      }
+    }
+    set({ currentStep: step, data: newData })
+  },
+  instructions: [],
+  setInstructions: (instructions: instruction[]) => {
+    const allVariableNames = new Set<string>()
+    for (let i = 0; i < instructions.length; i++) {
+      // local_variable_changes and global_variable_changes will be merged for now,
+      // so that the frontend retains the same behaviour. Will be changed once we decide
+      // how to deal with function scopes in the frontend
+      const newInstruction = {
+        ...instructions[i].local_variable_changes,
+        ...instructions[i].global_variable_changes,
+      }
+      Object.keys(newInstruction).forEach((name) => allVariableNames.add(name))
+    }
+    set({
+      currentStep: 0,
+      instructions,
+      data: [],
+      allVariableNames: [...allVariableNames],
+    })
+  },
+  data: [],
+  allVariableNames: [],
+}))
+
+export default useExecutionStore


### PR DESCRIPTION
This PR adds a store (using [zustand](https://github.com/pmndrs/zustand)) to the frontend, meant for commonly used global state. Currently, it is used to store execution information, as that is used in many places like the ControlBar, DataTable, and eventually the Visualization component.

This PR is a refactor only, so all behaviour should remain the same. Tested frontend locally.