### PR TITLE
Fix/global variables not found

### DIFF
--- a/services/executor/tests/util.py
+++ b/services/executor/tests/util.py
@@ -11,3 +11,7 @@ class MatchesRegex:
 
     def __eq__(self, other):
         return isinstance(other, str) and bool(self.regex.match(other))
+
+
+def MatchesFunctionString(name):
+    return MatchesRegex(f"<function {re.escape(name)} at 0x[0-9a-f]*>")


### PR DESCRIPTION
This PR fixes the bug in this [issue](https://github.com/huajun07/codesketcher/issues/37).

Previously, we were running the code with `debugger.run(code, globals={}, locals={})`. We should actually have been doing this: `debugger.run(code, globals=empty_dict, locals=empty_dict)`, where empty_dict both points to the same dictionary. This is because at the module level, [globals are equal to locals](https://docs.python.org/3/library/functions.html#locals).

Tested by adding the following testcase:
```python
def f1():
  a = 1
def f2():
  f1()
f2()
```

Other problematic code has also been tested locally in the frontend, such as this Floyd Warshall code where `nV` cannot be accessed:
```python
# Floyd Warshall Algorithm in python
# The number of vertices
nV = 4

INF = 999

# Algorithm implementation
def floyd_warshall(G):
    distance = list(map(lambda i: list(map(lambda j: j, i)), G))

    # Adding vertices individually
    for k in range(nV):
        for i in range(nV):
            for j in range(nV):
                distance[i][j] = min(distance[i][j], distance[i][k] + distance[k][j])

G = [[0, 3, INF, 5],
         [2, 0, INF, 4],
         [INF, 1, 0, INF],
         [INF, INF, 2, 0]]
floyd_warshall(G)
```