### PR TITLE
Fix:executor import statements

### DIFF
--- a/services/executor/tests/test_main.py
+++ b/services/executor/tests/test_main.py
@@ -667,3 +667,60 @@ def test_global_function_access():
         ],
         "output": "",
     }
+
+
+def test_imports():
+    result = execute(
+        {
+            "code": dedent(
+                """\
+                    import heapq"""
+            )
+        }
+    )
+
+    assert result == {
+        "executed": True,
+        "data": [
+            {
+                "line_number": 1,
+                "local_variable_changes": {},
+                "global_variable_changes": {},
+                "function_scope": [],
+            },
+        ],
+        "output": "",
+    }
+
+
+def test_from_imports():
+    result = execute(
+        {
+            "code": dedent(
+                """\
+                    from heapq import heappush, heappop"""
+            )
+        }
+    )
+
+    assert result == {
+        "executed": True,
+        "data": [
+            {
+                "line_number": 1,
+                "local_variable_changes": {
+                    "heappush": {
+                        "type": "builtin_function_or_method",
+                        "value": "<built-in function heappush>",
+                    },
+                    "heappop": {
+                        "type": "builtin_function_or_method",
+                        "value": "<built-in function heappop>",
+                    },
+                },
+                "global_variable_changes": {},
+                "function_scope": [],
+            }
+        ],
+        "output": "",
+    }


### PR DESCRIPTION
When importing some libraries, Python will call a bunch of internal functions, causing our debugger to pick up on a bunch of undesired variables. Some of these variables cannot be pickled (causing `copy.deepcopy` to crash) or cannot be stringified (causing `.__str__()` to crash).

## Fix

When we are on a line that imports a library, we ignore all the future frames until we reach a frame that equals our current frame.

```
current frame
vvvvvvvvvvvv #ignored
import frame
...
...
import frame
^^^^^^^^^^ # ignored
current frame
```

## Test

Have added testcases to the executor service. Also tested with frontend by running this python code, which previously threw an error:

```python
from heapq import heappush, heappop

# Number of vertices, number of edges
n, m = map(int, input().split(' '))
adj = [[] for _ in range(n)]

# Read edges in the format: vertex vertex weight
for i in range(m):
  u, v, w = map(int, input().split(' '))
  adj[u].append((v, w))
  adj[v].append((u, w))

distances = [-1 for _ in range(n)]
distances[0] = 0

# Run Dijkstra's algorithm from node 0 to find
# shortest distance to all nodes
pq = []
heappush(pq, (0, 0))
while len(pq) > 0:
  distance, u = heappop(pq)
  if distances[u] != distance:
    continue
  for (v, w) in adj[u]:
    if distances[v] != -1 and distances[v] < distance + w:
      continue
    distances[v] = distance + w
    heappush(pq, (distances[v], v))
```
