### PR TITLE
chore: upgrade version to 1.0.0

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -6,7 +6,6 @@
 	"packages": {
 		"": {
 			"name": "backend",
-			"version": "1.0.0",
 			"dependencies": {
 				"@aws-sdk/client-lambda": "^3.338.0",
 				"@vendia/serverless-express": "^4.10.4",

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "backend",
-	"version": "0.0.1",
+	"version": "1.0.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "backend",
-			"version": "0.0.1",
+			"version": "1.0.0",
 			"dependencies": {
 				"@aws-sdk/client-lambda": "^3.338.0",
 				"@vendia/serverless-express": "^4.10.4",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "backend",
-	"version": "0.0.1",
+	"version": "1.0.0",
 	"scripts": {
 		"dev": "cp env/.env.local .env && nodemon src/index.ts",
 		"test": "jest",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,5 @@
 {
 	"name": "backend",
-	"version": "1.0.0",
 	"scripts": {
 		"dev": "cp env/.env.local .env && nodemon src/index.ts",
 		"test": "jest",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -6,7 +6,6 @@
   "packages": {
     "": {
       "name": "codesketcher-frontend",
-      "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
         "@chakra-ui/icons": "^2.0.19",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,5 @@
 {
   "name": "codesketcher-frontend",
-  "version": "1.0.0",
   "description": "",
   "scripts": {
     "start": "react-scripts start",

--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "codesketcher",
+  "version": "1.0.0",
+  "description": "Visualise your code in action!",
+  "author": "",
+  "license": "ISC"
+}

--- a/services/executor/package-lock.json
+++ b/services/executor/package-lock.json
@@ -6,7 +6,6 @@
   "packages": {
     "": {
       "name": "executor",
-      "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
         "serverless": "^3.31.0"

--- a/services/executor/package.json
+++ b/services/executor/package.json
@@ -1,4 +1,7 @@
 {
+  "name": "executor",
+  "version": "1.0.0",
+  "license": "ISC",
   "scripts": {
     "deploy:dev": "serverless deploy --stage dev",
     "deploy:prod": "serverless deploy --stage prod"

--- a/services/executor/package.json
+++ b/services/executor/package.json
@@ -1,6 +1,5 @@
 {
   "name": "executor",
-  "version": "1.0.0",
   "license": "ISC",
   "scripts": {
     "deploy:dev": "serverless deploy --stage dev",


### PR DESCRIPTION
This PR sets the version of all three packages (frontend, backend, executor) to 1.0.0 for our first release :).

We will be following [semver](https://semver.org/). Any hotfixes before milestone 3 will increment the PATCH version (e.g. 1.0.1, 1.0.2, etc...). Version 1.1.0 will likely be released for milestone 3.