### PR TITLE
Feat: Load Code Example

### DIFF
--- a/frontend/src/components/CodeIDE/CodeIDEModals.tsx
+++ b/frontend/src/components/CodeIDE/CodeIDEModals.tsx
@@ -86,7 +86,7 @@ export const CodeIDEModal = (props: ModalProps) => {
   }
 
   const header = () => {
-    if (variant === 'create') return 'Create new file'
+    if (variant === 'create' || variant === 'save') return 'Create new file'
     if (variant === 'rename') return 'Rename file'
     if (variant === 'delete') return 'Delete file?'
     return ''

--- a/frontend/src/components/IO/index.tsx
+++ b/frontend/src/components/IO/index.tsx
@@ -19,8 +19,9 @@ interface IOProps {
 }
 
 export const IO = (props: IOProps) => {
-  const { input, setInput, curFile } = useUserDataStore(
+  const { input, setInput, curFile, loggedIn } = useUserDataStore(
     (state) => ({
+      loggedIn: state.loggedIn,
       input: state.input,
       setInput: state.setInput,
       curFile: state.curFile,
@@ -44,7 +45,7 @@ export const IO = (props: IOProps) => {
               borderColor="gray.200"
               _selected={{ bg: 'hsl(0deg 0% 97.5%)' }}
             >
-              Input{input !== curFile.input && <sup>*</sup>}
+              Input{input !== curFile.input && loggedIn && <sup>*</sup>}
             </Tab>
             <Tab
               _selected={{ bg: 'hsl(0deg 0% 97.5%)' }}

--- a/frontend/src/components/Visual/FAQModal/CodeExample.tsx
+++ b/frontend/src/components/Visual/FAQModal/CodeExample.tsx
@@ -1,0 +1,154 @@
+import { MdContentCopy } from 'react-icons/md'
+import {
+  Accordion,
+  AccordionButton,
+  AccordionIcon,
+  AccordionItem,
+  AccordionPanel,
+  Box,
+  Button,
+  Center,
+  Code,
+  Heading,
+  HStack,
+  IconButton,
+  Image,
+  Spacer,
+  Text,
+} from '@chakra-ui/react'
+import { useUserDataStore } from 'stores'
+import { shallow } from 'zustand/shallow'
+
+const dijkstraCode = `\
+from heapq import heappush, heappop
+
+# Number of vertices, number of edges
+n, m = map(int, input().split(' '))
+adj = [[] for _ in range(n)]
+
+# Read edges in the format: vertex vertex weight
+for i in range(m):
+  u, v, w = map(int, input().split(' '))
+  adj[u].append((v, w))
+  adj[v].append((u, w))
+
+distances = [-1 for _ in range(n)]
+distances[0] = 0
+
+# Run Dijkstra's algorithm from node 0 to find
+# shortest distance to all nodes
+pq = []
+heappush(pq, (0, 0))
+while len(pq) > 0:
+  distance, u = heappop(pq)
+  if distances[u] != distance:
+    continue
+  for (v, w) in adj[u]:
+    if distances[v] != -1 and distances[v] < distance + w:
+      continue
+    distances[v] = distance + w
+    heappush(pq, (distances[v], v))`
+
+const dijkstraInput = `\
+5 6
+0 1 10
+1 2 20
+2 3 5
+2 4 15
+3 4 5
+0 4 30`
+
+export const CodeExamples = (props: { toggle: () => void }) => {
+  const { setCode, setInput, setIdx } = useUserDataStore(
+    (state) => ({
+      setCode: state.setCode,
+      setInput: state.setInput,
+      setIdx: state.setIdx,
+    }),
+    shallow,
+  )
+  return (
+    <>
+      <Heading as="h3" size="lg" mt={4}>
+        Code Examples
+      </Heading>
+      <Text>Here are some codes and inputs for you to try out!</Text>
+
+      <Accordion defaultIndex={[]} allowMultiple mt={4}>
+        <AccordionItem>
+          <Text as="h4" size="md">
+            <AccordionButton>
+              <Box as="b" flex="1" textAlign="left">
+                Dijkstra's Algorithm (Single Source Shortest Path)
+              </Box>
+              <AccordionIcon />
+            </AccordionButton>
+          </Text>
+          <AccordionPanel pb={4}>
+            <HStack spacing={0} marginBottom={2}>
+              <Center>Code: </Center>
+              <IconButton
+                icon={<MdContentCopy />}
+                aria-label="copy"
+                size="sm"
+                variant="ghost"
+                onClick={() => {
+                  navigator.clipboard.writeText(dijkstraInput)
+                }}
+              />
+              <Spacer />
+              <Button
+                colorScheme="blue"
+                onClick={() => {
+                  setIdx(0)
+                  setCode(dijkstraCode)
+                  setInput(dijkstraInput)
+                  props.toggle()
+                }}
+              >
+                Load Code
+              </Button>
+            </HStack>
+            <Code display="block" whiteSpace="pre">
+              {dijkstraCode}
+            </Code>
+            <HStack spacing={0}>
+              <Center>Input: </Center>
+              <IconButton
+                icon={<MdContentCopy />}
+                aria-label="copy"
+                variant="ghost"
+                size="sm"
+                onClick={() => {
+                  navigator.clipboard.writeText(dijkstraInput)
+                }}
+              />
+            </HStack>
+            <Code display="block" whiteSpace="pre">
+              {dijkstraInput}
+            </Code>
+            <br />
+            <Center>
+              <Image
+                src="faq/dijkstra_settings.png"
+                alt="Dijkstra settings"
+                width="50%"
+                display="inline"
+              />
+              <Image
+                src="faq/dijkstra_graph.png"
+                alt="Dijkstra graph"
+                width="35%"
+                display="inline"
+                borderLeft="1px"
+                borderLeftColor="blackAlpha.400"
+                paddingLeft={4}
+              />
+            </Center>
+            <br />
+          </AccordionPanel>
+        </AccordionItem>
+      </Accordion>
+    </>
+  )
+}

--- a/frontend/src/components/Visual/FAQModal/CodeExample.tsx
+++ b/frontend/src/components/Visual/FAQModal/CodeExample.tsx
@@ -1,4 +1,4 @@
-import { MdContentCopy } from 'react-icons/md'
+import { CopyIcon } from '@chakra-ui/icons'
 import {
   Accordion,
   AccordionButton,
@@ -15,6 +15,7 @@ import {
   Image,
   Spacer,
   Text,
+  useToast,
 } from '@chakra-ui/react'
 import { useUserDataStore } from 'stores'
 import { shallow } from 'zustand/shallow'
@@ -67,6 +68,16 @@ export const CodeExamples = (props: { toggle: () => void }) => {
     }),
     shallow,
   )
+  const toast = useToast()
+  const copyToast = () => {
+    toast.closeAll()
+    toast({
+      title: 'Copied To Clipboard',
+      status: 'success',
+      position: 'top',
+      duration: 800,
+    })
+  }
   return (
     <>
       <Heading as="h3" size="lg" mt={4}>
@@ -88,12 +99,13 @@ export const CodeExamples = (props: { toggle: () => void }) => {
             <HStack spacing={0} marginBottom={2}>
               <Center>Code: </Center>
               <IconButton
-                icon={<MdContentCopy />}
+                icon={<CopyIcon />}
                 aria-label="copy"
                 size="sm"
-                variant="ghost"
+                variant="link"
                 onClick={() => {
-                  navigator.clipboard.writeText(dijkstraInput)
+                  navigator.clipboard.writeText(dijkstraCode)
+                  copyToast()
                 }}
               />
               <Spacer />
@@ -112,15 +124,16 @@ export const CodeExamples = (props: { toggle: () => void }) => {
             <Code display="block" whiteSpace="pre">
               {dijkstraCode}
             </Code>
-            <HStack spacing={0}>
+            <HStack spacing={0} marginY={2}>
               <Center>Input: </Center>
               <IconButton
-                icon={<MdContentCopy />}
+                icon={<CopyIcon />}
                 aria-label="copy"
-                variant="ghost"
+                variant="link"
                 size="sm"
                 onClick={() => {
                   navigator.clipboard.writeText(dijkstraInput)
+                  copyToast()
                 }}
               />
             </HStack>

--- a/frontend/src/components/Visual/FAQModal/GettingStarted.tsx
+++ b/frontend/src/components/Visual/FAQModal/GettingStarted.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react'
 import {
   Accordion,
   AccordionButton,
@@ -10,57 +9,10 @@ import {
   Code,
   Heading,
   Image,
-  Modal,
-  ModalBody,
-  ModalCloseButton,
-  ModalContent,
-  ModalOverlay,
-  Tab,
-  TabList,
-  TabPanel,
-  TabPanels,
-  Tabs,
   Text,
 } from '@chakra-ui/react'
 
-interface FAQModalProps {
-  open: boolean
-  toggle: () => void
-}
-
-export const FAQModal = (props: FAQModalProps) => {
-  const { open, toggle } = props
-  const [index, setIndex] = useState(0)
-  return (
-    <Modal isOpen={open} onClose={toggle}>
-      <ModalOverlay />
-      <ModalContent maxW="1000px" py={8}>
-        <ModalCloseButton />
-        <ModalBody>
-          <Tabs
-            defaultIndex={index}
-            onChange={(newIndex) => setIndex(newIndex)}
-          >
-            <TabList>
-              <Tab>Getting Started</Tab>
-              <Tab>Code Examples</Tab>
-            </TabList>
-            <TabPanels>
-              <TabPanel>
-                <GettingStarted />
-              </TabPanel>
-              <TabPanel>
-                <CodeExamples />
-              </TabPanel>
-            </TabPanels>
-          </Tabs>
-        </ModalBody>
-      </ModalContent>
-    </Modal>
-  )
-}
-
-const GettingStarted = () => {
+export const GettingStarted = () => {
   return (
     <>
       <Heading as="h3" size="lg">
@@ -271,99 +223,6 @@ const GettingStarted = () => {
           paddingLeft={4}
         />
       </Center>
-    </>
-  )
-}
-
-const dijkstraCode = `\
-from heapq import heappush, heappop
-
-# Number of vertices, number of edges
-n, m = map(int, input().split(' '))
-adj = [[] for _ in range(n)]
-
-# Read edges in the format: vertex vertex weight
-for i in range(m):
-  u, v, w = map(int, input().split(' '))
-  adj[u].append((v, w))
-  adj[v].append((u, w))
-
-distances = [-1 for _ in range(n)]
-distances[0] = 0
-
-# Run Dijkstra's algorithm from node 0 to find
-# shortest distance to all nodes
-pq = []
-heappush(pq, (0, 0))
-while len(pq) > 0:
-  distance, u = heappop(pq)
-  if distances[u] != distance:
-    continue
-  for (v, w) in adj[u]:
-    if distances[v] != -1 and distances[v] < distance + w:
-      continue
-    distances[v] = distance + w
-    heappush(pq, (distances[v], v))`
-
-const dijkstraInput = `\
-5 6
-0 1 10
-1 2 20
-2 3 5
-2 4 15
-3 4 5
-0 4 30`
-
-const CodeExamples = () => {
-  return (
-    <>
-      <Heading as="h3" size="lg" mt={4}>
-        Code Examples
-      </Heading>
-      <Text>Here are some codes and inputs for you to try out!</Text>
-
-      <Accordion defaultIndex={[]} allowMultiple mt={4}>
-        <AccordionItem>
-          <Text as="h4" size="md">
-            <AccordionButton>
-              <Box as="b" flex="1" textAlign="left">
-                Dijkstra's Algorithm (Single Source Shortest Path)
-              </Box>
-              <AccordionIcon />
-            </AccordionButton>
-          </Text>
-          <AccordionPanel pb={4}>
-            <Code display="block" whiteSpace="pre">
-              {dijkstraCode}
-            </Code>
-
-            <Text mt={2}>Input:</Text>
-
-            <Code display="block" whiteSpace="pre">
-              {dijkstraInput}
-            </Code>
-            <br />
-            <Center>
-              <Image
-                src="faq/dijkstra_settings.png"
-                alt="Dijkstra settings"
-                width="50%"
-                display="inline"
-              />
-              <Image
-                src="faq/dijkstra_graph.png"
-                alt="Dijkstra graph"
-                width="35%"
-                display="inline"
-                borderLeft="1px"
-                borderLeftColor="blackAlpha.400"
-                paddingLeft={4}
-              />
-            </Center>
-            <br />
-          </AccordionPanel>
-        </AccordionItem>
-      </Accordion>
     </>
   )
 }

--- a/frontend/src/components/Visual/FAQModal/index.tsx
+++ b/frontend/src/components/Visual/FAQModal/index.tsx
@@ -1,0 +1,53 @@
+import { useState } from 'react'
+import {
+  Modal,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalOverlay,
+  Tab,
+  TabList,
+  TabPanel,
+  TabPanels,
+  Tabs,
+} from '@chakra-ui/react'
+
+import { CodeExamples } from './CodeExample'
+import { GettingStarted } from './GettingStarted'
+
+interface FAQModalProps {
+  open: boolean
+  toggle: () => void
+}
+
+export const FAQModal = (props: FAQModalProps) => {
+  const { open, toggle } = props
+  const [index, setIndex] = useState(0)
+  return (
+    <Modal isOpen={open} onClose={toggle}>
+      <ModalOverlay />
+      <ModalContent maxW="1000px" py={8}>
+        <ModalCloseButton />
+        <ModalBody>
+          <Tabs
+            defaultIndex={index}
+            onChange={(newIndex) => setIndex(newIndex)}
+          >
+            <TabList>
+              <Tab>Getting Started</Tab>
+              <Tab>Code Examples</Tab>
+            </TabList>
+            <TabPanels>
+              <TabPanel>
+                <GettingStarted />
+              </TabPanel>
+              <TabPanel>
+                <CodeExamples toggle={toggle} />
+              </TabPanel>
+            </TabPanels>
+          </Tabs>
+        </ModalBody>
+      </ModalContent>
+    </Modal>
+  )
+}

--- a/frontend/src/components/Visual/VisualArea.tsx
+++ b/frontend/src/components/Visual/VisualArea.tsx
@@ -3,6 +3,7 @@ import { AddIcon, InfoIcon } from '@chakra-ui/icons'
 import {
   Button,
   Center,
+  Code,
   Flex,
   Tab,
   TabList,
@@ -67,7 +68,8 @@ export const VisualArea = () => {
           </TabPanels>
         ) : (
           <Center h="full" w="full">
-            Click the "+" button above to add a visualization and get started!
+            Click the <Code>+</Code> button above to add a visualization and get
+            started!
           </Center>
         )}
       </Tabs>

--- a/frontend/src/components/Visual/VisualArea.tsx
+++ b/frontend/src/components/Visual/VisualArea.tsx
@@ -68,8 +68,8 @@ export const VisualArea = () => {
           </TabPanels>
         ) : (
           <Center h="full" w="full">
-            Click the <Code>+</Code> button above to add a visualization and get
-            started!
+            Click the&nbsp; <Code>+</Code>&nbsp; button above to add a
+            visualization and get started!
           </Center>
         )}
       </Tabs>


### PR DESCRIPTION
# Feature
- Load code from code example
- Added copy to clipboard buttons
<img width="986" alt="image" src="https://github.com/huajun07/codesketcher/assets/35941406/bb66e7dd-4348-42fa-8ae7-267dda07a5da">


## Other minor changes:
- fix bug where header of modal not shown when saving new code
- Replace "+" with code version
- Disable * on Input when not logged in
- Refactored file structure of FAQ modal