### PR TITLE
Chore/aws security

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,15 @@ This repository contains the following systems and services:
 - [frontend](https://github.com/huajun07/codesketcher/tree/main/frontend) - web interface for user to enter their code, displays variable data and objects through code simulation
 - [services](services) - contain microservices called by the backend including code execution
 
+## Setting Up
+
+In order to run the services, you need to configure your shell to have the correct AWS credentials.
+Configure two IAM users, one for development (with access to development resources), and one for production (With access to production resources).
+Then setup the following in your shell:
+
+- Set the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables manually OR
+- Save the credentials in `~/.aws/credentials` (details [here](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html))
+
 ## Deployment
 
 - Deployment is done via serverless (backend & services) and amplify (frontend)

--- a/backend/README.md
+++ b/backend/README.md
@@ -12,6 +12,12 @@ npm install
 To run the server locally:
 
 - Ensure that you have permissions to invoke the executor lambda. For example, set your `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables to an IAM user with the correct permissions.
+- Ensure that the following SSM parameters have been setup and the IAM user has access to them:
+  - `/codesketcher-$stage/rds/host`
+  - `/codesketcher-$stage/rds/name`
+  - `/codesketcher-$stage/rds/username`
+  - `/codesketcher-$stage/rds/password`
+  - `/codesketcher-$stage/google/client-id`
 - Run `npm run dev`
 
 To deploy to the dev/prod environments (NOTE: **Prod deployment should not be run locally**):
@@ -23,19 +29,20 @@ To deploy to the dev/prod environments (NOTE: **Prod deployment should not be ru
 
 Configuration is done through the `.env` file. Default configuration is available in `./env/.env.{stage}`
 
-| Name              | Description                               | Default        |
-| ----------------- | ----------------------------------------- | -------------- |
-| PORT              | Port the server listens on                | 8000           |
-| EXECUTOR_REGION   | AWS Region that the executor lambda is in | ap-southeast-1 |
-| EXECUTOR_NAME     | Name of the executor lambda               | executor       |
-| DB_HOST           | Host Address of DB                        | 127.0.0.1      |
-| DB_USERNAME       | DB Username                               |                |
-| DB_PASSWORD       | DB User password                          |                |
-| DB_NAME           | Database name                             |                |
-| DB_PORT           | DB Port                                   | 5432           |
-| DB_MIN_POOL_SIZE  | DB pool min no. of connections            | 50             |
-| DB_MAX_POOL_SIZE  | DB pool max no. of connections            | 200            |
-| DB_ENABLE_LOGGING | Toggles logging of DB queries             | false          |
+| Name              | Description                               | Default                                     |
+| ----------------- | ----------------------------------------- | ------------------------------------------- |
+| PORT              | Port the server listens on                | 8000                                        |
+| EXECUTOR_REGION   | AWS Region that the executor lambda is in | ap-southeast-1                              |
+| EXECUTOR_NAME     | Name of the executor lambda               | executor                                    |
+| DB_HOST           | Host Address of DB                        | `ssm:/codesketcher-$stage/rds/host`         |
+| DB_USERNAME       | DB Username                               | `ssm:/codesketcher-$stage/rds/username`     |
+| DB_PASSWORD       | DB User password                          | `ssm:/codesketcher-$stage/rds/password`     |
+| DB_NAME           | Database name                             | `ssm:/codesketcher-$stage/rds/name`         |
+| DB_PORT           | DB Port                                   | 5432                                        |
+| DB_MIN_POOL_SIZE  | DB pool min no. of connections            | 50                                          |
+| DB_MAX_POOL_SIZE  | DB pool max no. of connections            | 200                                         |
+| DB_ENABLE_LOGGING | Toggles logging of DB queries             | false                                       |
+| GOOGLE_CLIENT_ID  | Client ID to verify Google's JWT token    | `ssm:/codesketcher-$stage/google/client-id` |
 
 ## Postgresql Setup (macOS)
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -11,7 +11,7 @@ npm install
 
 To run the server locally:
 
-- Ensure that you have permissions to invoke the executor lambda. For example, set your `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables to an IAM user with the correct permissions.
+- Ensure that you have permissions to invoke the executor lambda.
 - Ensure that the following SSM parameters have been setup and the IAM user has access to them:
   - `/codesketcher-$stage/rds/host`
   - `/codesketcher-$stage/rds/name`

--- a/backend/env/.env.local
+++ b/backend/env/.env.local
@@ -2,7 +2,3 @@ NODE_ENV=local
 PORT=8000
 EXECUTOR_REGION=ap-southeast-1
 EXECUTOR_NAME=executor-dev
-DB_NAME=codesketcher
-DB_USERNAME=postgres
-DB_PASSWORD=password
-GOOGLE_CLIENT_ID=''

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,13 +1,16 @@
 {
 	"name": "backend",
 	"scripts": {
-		"dev": "cp env/.env.local .env && nodemon src/index.ts",
+		"dev": "source ./scripts/fetch-config.sh dev && cp env/.env.local .env && nodemon src/index.ts",
 		"test": "jest",
 		"build": "tsc",
 		"deploy:dev": "cp env/.env.development .env && serverless deploy --stage dev",
 		"deploy:prod": "cp env/.env.production .env && serverless deploy --stage prod",
 		"start": "cp env/.env.production .env && node build/index.js",
-		"db:migrate": "sequelize-cli db:migrate"
+		"db:migrate:dev": "source ./scripts/fetch-config.sh dev && sequelize-cli db:migrate",
+		"db:create:dev": "source ./scripts/fetch-config.sh dev && sequelize-cli db:create",
+		"db:migrate:prod": "source ./scripts/fetch-config.sh prod && sequelize-cli db:migrate",
+		"db:create:prod": "source ./scripts/fetch-config.sh prod && sequelize-cli db:create"
 	},
 	"devDependencies": {
 		"@types/convict": "^6.1.1",

--- a/backend/scripts/fetch-config.sh
+++ b/backend/scripts/fetch-config.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+set -e # exit after first failed command
+
+stage=$1
+
+if [[ $stage != "dev" && $stage != "prod" ]] ; then
+    echo "Stage must be either 'dev' or 'prod'"
+    exit 1
+fi
+
+export DB_HOST=$(aws ssm get-parameter --name /codesketcher-$stage/rds/host --with-decryption --output text --query "Parameter.Value")
+export DB_USERNAME=$(aws ssm get-parameter --name /codesketcher-$stage/rds/username --with-decryption --output text --query "Parameter.Value")
+export DB_PASSWORD=$(aws ssm get-parameter --name /codesketcher-$stage/rds/password --with-decryption --output text --query "Parameter.Value")
+export DB_NAME=$(aws ssm get-parameter --name /codesketcher-$stage/rds/name --output text --query "Parameter.Value")
+export GOOGLE_CLIENT_ID=$(aws ssm get-parameter --name /codesketcher-$stage/google/client-id --output text --query "Parameter.Value")

--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -30,8 +30,8 @@ functions:
           method: '*'
           path: /{any+}
     environment:
-      DB_HOST: ${env:DB_HOST}
-      DB_NAME: ${env:DB_NAME}
-      DB_USERNAME: ${env:DB_USERNAME}
-      DB_PASSWORD: ${env:DB_PASSWORD}
-      GOOGLE_CLIENT_ID: ${env:GOOGLE_CLIENT_ID}
+      DB_HOST: ${ssm:/codesketcher-${sls:stage}/rds/host}
+      DB_NAME: ${ssm:/codesketcher-${sls:stage}/rds/name}
+      DB_USERNAME: ${ssm:/codesketcher-${sls:stage}/rds/username}
+      DB_PASSWORD: ${ssm:/codesketcher-${sls:stage}/rds/password}
+      GOOGLE_CLIENT_ID: ${ssm:/codesketcher-${sls:stage}/google/client-id}

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -26,10 +26,17 @@ See the section about [deployment](https://facebook.github.io/create-react-app/d
 
 # Environment Variables
 
-| Name                        | Description            | Default | Required |
-| --------------------------- | ---------------------- | ------- | -------- |
-| REACT_APP_EXECUTOR_ENDPOINT | Backend Endpoint       |         | Yes      |
-| REACT_APP_GOOGLE_CLIENT_ID  | Google oAuth Client ID |         | Yes      |
+Configuration is obtained from SSM, but can be overwritten in a local `.env` file. Ensure that the following SSM parameters have been setup and your IAM user has access to them:
+
+- `/codesketcher-$stage/api/endpoint`
+- `/codesketcher-$stage/google/client-id`
+
+| Name                        | Description            | Default                                 | Required |
+| --------------------------- | ---------------------- | --------------------------------------- | -------- |
+| REACT_APP_EXECUTOR_ENDPOINT | Backend Endpoint       | `ssm:/codesketcher-$stage/api/endpoint` | Yes      |
+| REACT_APP_GOOGLE_CLIENT_ID  | Google oAuth Client ID | `/codesketcher-$stage/google/client-id` | Yes      |
+
+Or if you would like to use your own values:
 
 ```sh
 cp .env.example .env

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -31,10 +31,10 @@ Configuration is obtained from SSM, but can be overwritten in a local `.env` fil
 - `/codesketcher-$stage/api/endpoint`
 - `/codesketcher-$stage/google/client-id`
 
-| Name                        | Description            | Default                                 | Required |
-| --------------------------- | ---------------------- | --------------------------------------- | -------- |
-| REACT_APP_EXECUTOR_ENDPOINT | Backend Endpoint       | `ssm:/codesketcher-$stage/api/endpoint` | Yes      |
-| REACT_APP_GOOGLE_CLIENT_ID  | Google oAuth Client ID | `/codesketcher-$stage/google/client-id` | Yes      |
+| Name                        | Description            | Default                                     | Required |
+| --------------------------- | ---------------------- | ------------------------------------------- | -------- |
+| REACT_APP_EXECUTOR_ENDPOINT | Backend Endpoint       | `ssm:/codesketcher-$stage/api/endpoint`     | Yes      |
+| REACT_APP_GOOGLE_CLIENT_ID  | Google oAuth Client ID | `ssm:/codesketcher-$stage/google/client-id` | Yes      |
 
 Or if you would like to use your own values:
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,8 +2,8 @@
   "name": "codesketcher-frontend",
   "description": "",
   "scripts": {
-    "start": "react-scripts start",
-    "build": "react-scripts build",
+    "start": "source ./scripts/fetch-config.sh dev && react-scripts start",
+    "build": "source ./scripts/fetch-config.sh prod && react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
     "lint-no-fix": "eslint ./ --ignore-path .gitignore && prettier . -c",

--- a/frontend/scripts/fetch-config.sh
+++ b/frontend/scripts/fetch-config.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+set -e # exit after first failed command
+
+stage=$1
+
+if [[ $stage != "dev" && $stage != "prod" ]] ; then
+    echo "Stage must be either 'dev' or 'prod'"
+    exit 1
+fi
+
+export REACT_APP_EXECUTOR_ENDPOINT=$(aws ssm get-parameter --name /codesketcher-$stage/api/endpoint --output text --query "Parameter.Value")
+export REACT_APP_GOOGLE_CLIENT_ID=$(aws ssm get-parameter --name /codesketcher-$stage/google/client-id --output text --query "Parameter.Value")

--- a/services/executor/README.md
+++ b/services/executor/README.md
@@ -22,10 +22,6 @@ Before deploying, ensure that you have setup the following:
 
 ### Deployment
 
-- Configure your shell to use the correct IAM user as the AWS profile. You can do so by:
-  - Setting the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables manually OR
-  - Saving the credentials in `~/.aws/credentials` (details [here](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html))
-- The chosen IAM user should have the appropriate permissions to deploy the required resources.
 - Run `npm run deploy:dev` or `npm run deploy:prod` to deploy.
 
 ## Running Tests

--- a/services/executor/README.md
+++ b/services/executor/README.md
@@ -9,10 +9,24 @@ npm install
 
 ## Getting Started
 
-To deploy to the dev/prod environments (NOTE: **Prod deployment should not be run locally**):
+This service's deployment is handled by the [Serverless](https://www.serverless.com/) framework.
+To deploy to the dev/prod environments:
 
-- Set the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables for the correct IAM user
-- Run `npm run deploy:dev` or `npm run deploy:prod` to deploy
+### Infra Dependencies
+
+Before deploying, ensure that you have setup the following:
+
+- An IAM role called `codesketcher-executor-lambda-no-perms` with **no permissions**. The executor lambda will take on this role, and it will not be able to touch any resources at all.
+- A private subnet, whose id is stored as a SSM parameter `/codesketcher-$stage/vpc/subnet-executor-id`. The executor lambda will live in this subnet. Note that this subnet should not be connected to the Internet at all (by not routing it to an Internet Gateway).
+- A security group, whose id is stored as a SSM parameter `/codesketcher-$stage/vpc/security-group-id`. Ensure that all inbound/outbound traffic are blocked.
+
+### Deployment
+
+- Configure your shell to use the correct IAM user as the AWS profile. You can do so by:
+  - Setting the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables manually OR
+  - Saving the credentials in `~/.aws/credentials` (details [here](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html))
+- The chosen IAM user should have the appropriate permissions to deploy the required resources.
+- Run `npm run deploy:dev` or `npm run deploy:prod` to deploy.
 
 ## Running Tests
 

--- a/services/executor/serverless.yml
+++ b/services/executor/serverless.yml
@@ -1,14 +1,20 @@
 service: executor
-frameworkVersion: '3'
+frameworkVersion: "3"
 
 provider:
   name: aws
   runtime: python3.10
   region: ap-southeast-1
+  iam:
+    role: !Sub arn:aws:iam::${AWS::AccountId}:role/codesketcher-executor-lambda-no-perms
+  vpc:
+    subnetIds:
+      - ${ssm:/codesketcher-${sls:stage}/vpc/subnet-executor-id}
+    securityGroupIds:
+      - ${ssm:/codesketcher-${sls:stage}/vpc/security-group-id}
 
 functions:
   executor:
     handler: executor/main.handler
     name: executor-${sls:stage}
     timeout: 1
-    


### PR DESCRIPTION
## AWS SSM

This PR shifts some of the more sensitive configuration, that was previously handled using local `.env` files, to AWS SSM's parameter store (and encrypted if necessary). The necessary parameters have been documented in each service's README.

Now all parameters have a single source of truth, vs before where we had to update GitHub secrets and local .env files. This should also help prevent accidentally pushing secrets to GitHub.

Note that running the applications locally now require you to use the correct IAM user, as we need to fetch the configuration from SSM first.

## Executor Lambda

The exeuctor lambda now resides in its own VPC with no Internet access at all. It also assumes a role with zero permissions, so that it cannot affect any other AWS resources.

## Production Deployment

Deployment should *hopefully* go smoothly, all resources for the production environment have already been created. The only issue to take note of is that the executor lambda might need to be removed manually and re-deployed (I had issues with the dev instance, I think shifting it into a VPC didn't work correctly).