### PR TITLE
Fix/executor imports and cloning

### DIFF
--- a/services/executor/tests/test_main.py
+++ b/services/executor/tests/test_main.py
@@ -167,7 +167,7 @@ def test_syntax_error():
         "executed": False,
         "data": [],
         "output": "",
-        "error": "unterminated string literal (detected at line 2) (<string>, line 2)",
+        "error": "unterminated string literal (detected at line 2) (user_code, line 2)",
     }
 
 
@@ -724,3 +724,26 @@ def test_from_imports():
         ],
         "output": "",
     }
+
+
+def test_unclonable_imports():
+    result = execute(
+        {
+            "code": dedent(
+                """\
+                    import threading
+                    def worker():
+                        print('Worker thread')
+                    threads = []
+                    for _ in range(2):
+                        t = threading.Thread(target=worker)
+                        threads.append(t)
+                        t.start()
+                    for t in threads:
+                        t.join()"""
+            )
+        }
+    )
+
+    assert result["output"] == "Worker thread\nWorker thread\n"
+    assert "error" not in result


### PR DESCRIPTION
This PR fixes this [cloning bug](https://github.com/huajun07/codesketcher/issues/66) and this [frame origin bug](https://github.com/huajun07/codesketcher/issues/65).

## Fix for [cloning bug](https://github.com/huajun07/codesketcher/issues/66)

We `compile` the user's code first with a filename, then we only consider frames with `frame.f_code.co_filename == our_filename`. This removes the need for the hacky checking if in a import thing we did previously.

## Fix for [frame origin bug](https://github.com/huajun07/codesketcher/issues/65)

We specify all raw variables with the prefix `raw` now (e.g. `current_raw_local_variables`). Then we only perform operations after we have converted them into our own format (that is JSON-friendly), so that they can be cloned.

## Testing

Added testcase to the executor service. Also tested in frontend:

```python
import threading
def worker():
    print('Worker thread')
threads = []
for _ in range(5):
    t = threading.Thread(target=worker)
    threads.append(t)
    t.start()
for t in threads:
    t.join()
```

![Screenshot 2023-07-03 at 10 17 25 PM](https://github.com/huajun07/codesketcher/assets/30954848/af3d7e33-bd8f-44e8-aa18-d54769e91b59)
