### PR TITLE
Chore/aws security

### DIFF
--- a/services/executor/Dockerfile
+++ b/services/executor/Dockerfile
@@ -1,0 +1,5 @@
+FROM --platform=linux/amd64 public.ecr.aws/lambda/python:3.10
+
+COPY executor/main.py ${LAMBDA_TASK_ROOT}
+
+CMD ["main.handler"]

--- a/services/executor/README.md
+++ b/services/executor/README.md
@@ -24,6 +24,15 @@ Before deploying, ensure that you have setup the following:
 
 - Run `npm run deploy:dev` or `npm run deploy:prod` to deploy.
 
+## Running Locally
+
+To run the Lambda locally:
+
+```bash
+docker build -t executor:local .
+docker run -p 9000:8080 executor:local
+```
+
 ## Running Tests
 
 ```bash

--- a/services/executor/executor/main.py
+++ b/services/executor/executor/main.py
@@ -1,3 +1,4 @@
+import os
 import bdb
 import inspect
 import json
@@ -178,7 +179,13 @@ def json_size_checker(return_data):
     return return_data
 
 
+def prepare_environment():
+    for env in os.environ.keys():
+        del os.environ[env]
+
+
 def execute(event):
+    prepare_environment()
     if not isinstance(event, dict):
         return {"executed": False, "error": "Input event is not a dictionary"}
 

--- a/services/executor/serverless.yml
+++ b/services/executor/serverless.yml
@@ -12,9 +12,15 @@ provider:
       - ${ssm:/codesketcher-${sls:stage}/vpc/subnet-executor-id}
     securityGroupIds:
       - ${ssm:/codesketcher-${sls:stage}/vpc/security-group-id}
+  ecr:
+    images:
+      executorimage:
+        path: ./
+        file: Dockerfile
 
 functions:
   executor:
-    handler: executor/main.handler
     name: executor-${sls:stage}
     timeout: 1
+    image:
+      name: executorimage


### PR DESCRIPTION
This PR adds Docker to the executor service, so that we can control the image we deploy to Lambda. It also helps us test locally in an environment closer to AWS's environment.

Note that the whole CF stack should be torndown and rebuilt when deploying to prod, as lambda's cannot switch from using uploaded code to getting an image from ECR.