### PR TITLE
Fix: Disallow slash in codename

### DIFF
--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -31,7 +31,7 @@ const addCode = async (
 	code: string,
 	input: string | undefined = undefined
 ) => {
-	if (codename.match(/[^a-zA-Z0-o\-._]/))
+	if (codename.match(/[^a-zA-Z0-9\-._]/))
 		throw new BadRequest(
 			"Codename can only contain alphanumeric and '_', '.' and '-'"
 		)
@@ -90,7 +90,7 @@ const updateCode = async (
 }
 
 const updateCodename = async (uid: string, codename: string, name: string) => {
-	if (name.match(/[^a-zA-Z0-o\-._]/))
+	if (name.match(/[^a-zA-Z0-9\-._]/))
 		throw new BadRequest(
 			"Codename can only contain alphanumeric and '_', '.' and '-'"
 		)

--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -31,6 +31,10 @@ const addCode = async (
 	code: string,
 	input: string | undefined = undefined
 ) => {
+	if (codename.match(/[^a-zA-Z0-o\-._]/))
+		throw new BadRequest(
+			"Codename can only contain alphanumeric and '_', '.' and '-'"
+		)
 	if (codename.length > NAME_LEN_LIMIT)
 		throw new LargePayload('Code name exceed limit')
 	if (code.length > LEN_LIMIT)
@@ -86,7 +90,11 @@ const updateCode = async (
 }
 
 const updateCodename = async (uid: string, codename: string, name: string) => {
-	if (codename.length > NAME_LEN_LIMIT)
+	if (name.match(/[^a-zA-Z0-o\-._]/))
+		throw new BadRequest(
+			"Codename can only contain alphanumeric and '_', '.' and '-'"
+		)
+	if (name.length > NAME_LEN_LIMIT)
 		throw new LargePayload('Code name exceed limit')
 	try {
 		const [affectedCount, data] = await Code.update(

--- a/frontend/src/components/CodeIDE/CodeIDEModals.tsx
+++ b/frontend/src/components/CodeIDE/CodeIDEModals.tsx
@@ -45,8 +45,11 @@ export const CodeIDEModal = (props: ModalProps) => {
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) =>
     setInput(e.target.value)
   const checkError = () => {
-    if (input.includes('/'))
-      return { err: true, errorMsg: 'Name cannot contain /' }
+    if (input.match(/[^a-zA-Z0-o\-._]/))
+      return {
+        err: true,
+        errorMsg: 'Name must only contain alphanumeric or .-_',
+      }
     if (input === '') return { err: true, errorMsg: 'Name cannot be blank' }
     if (input.length > 100) return { err: true, errorMsg: 'Name is too long' }
     if (variant === 'rename' && codenames[curIdx] === input)

--- a/frontend/src/components/CodeIDE/CodeIDEModals.tsx
+++ b/frontend/src/components/CodeIDE/CodeIDEModals.tsx
@@ -45,6 +45,8 @@ export const CodeIDEModal = (props: ModalProps) => {
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) =>
     setInput(e.target.value)
   const checkError = () => {
+    if (input.includes('/'))
+      return { err: true, errorMsg: 'Name cannot contain /' }
     if (input === '') return { err: true, errorMsg: 'Name cannot be blank' }
     if (input.length > 100) return { err: true, errorMsg: 'Name is too long' }
     if (variant === 'rename' && codenames[curIdx] === input)

--- a/frontend/src/components/CodeIDE/CodeIDEModals.tsx
+++ b/frontend/src/components/CodeIDE/CodeIDEModals.tsx
@@ -45,7 +45,7 @@ export const CodeIDEModal = (props: ModalProps) => {
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) =>
     setInput(e.target.value)
   const checkError = () => {
-    if (input.match(/[^a-zA-Z0-o\-._]/))
+    if (input.match(/[^a-zA-Z0-9\-._]/))
       return {
         err: true,
         errorMsg: 'Name must only contain alphanumeric or .-_',


### PR DESCRIPTION
# Bug Fix
Fixes #75 
- Disallows creating/renaming files with names that contains `/`
- Disabled on both frontend and backend

<img width="448" alt="image" src="https://github.com/huajun07/codesketcher/assets/35941406/ebb660a4-b284-4ad2-a9fa-7ea3b1954fc1">

### Notes
- Also fixed minor bug found that checks old codename instead of new one (in backend rename function)
