### PR TITLE
Feat/filter steps

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "local": "react-scripts start",
     "dev": "NODE_ENV=dev && source ./scripts/fetch-config.sh && react-scripts start",
-    "build": "NODE_ENV=local && source ./scripts/fetch-config.sh && react-scripts build",
+    "build": "source ./scripts/fetch-config.sh && react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
     "lint-no-fix": "eslint ./ --ignore-path .gitignore && prettier . -c",

--- a/frontend/src/components/CodeIDE/CodeIDE.tsx
+++ b/frontend/src/components/CodeIDE/CodeIDE.tsx
@@ -20,11 +20,11 @@ export const CodeIDE = (props: codeIDEProps) => {
   const updateSelectedLineNumbers = useExecutionStore(
     (state) => state.updateSelectedLineNumbers,
   )
-  const { code, setCode, curFile } = useUserDataStore(
+  const { code, setCode, fileIndex } = useUserDataStore(
     (state) => ({
       code: state.code,
       setCode: state.setCode,
-      curFile: state.curFile,
+      fileIndex: state.curIdx,
     }),
     shallow,
   )
@@ -51,7 +51,7 @@ export const CodeIDE = (props: codeIDEProps) => {
     breakpointsExtension.current = createBreakpointsExtension(
       breakpointsExtensionCallback,
     )
-  }, [curFile, breakpointsExtensionCallback])
+  }, [fileIndex, breakpointsExtensionCallback])
 
   const placeholder = 'Enter your python code here!\nE.g. a = [1, 2, 3]'
   return (

--- a/frontend/src/components/CodeIDE/CodeMirrorBreakpointExtension.ts
+++ b/frontend/src/components/CodeIDE/CodeMirrorBreakpointExtension.ts
@@ -1,0 +1,93 @@
+import { RangeSet, StateEffect, StateField } from '@codemirror/state'
+import { EditorView, gutter, GutterMarker } from '@codemirror/view'
+
+// A CodeMirror extension that allows adding breakpoints and keeping track of which lines they are on.
+// Reference: https://codemirror.net/examples/gutter/
+function createBreakpointsExtension(
+  updateBreakpoints: (
+    state: EditorView['state'],
+    set: RangeSet<GutterMarker>,
+  ) => void,
+) {
+  let state: EditorView['state'] | null = null
+
+  const breakpointMarker = new (class extends GutterMarker {
+    override toDOM() {
+      return document.createTextNode('🔴')
+    }
+  })()
+
+  const breakpointEffect = StateEffect.define<{ pos: number; on: boolean }>({
+    map: (val, mapping) => ({ pos: mapping.mapPos(val.pos), on: val.on }),
+  })
+
+  const breakpointState = StateField.define<RangeSet<GutterMarker>>({
+    create() {
+      return RangeSet.empty
+    },
+    update(set, transaction) {
+      set = set.map(transaction.changes)
+      for (const e of transaction.effects) {
+        if (e.is(breakpointEffect)) {
+          if (e.value.on)
+            set = set.update({ add: [breakpointMarker.range(e.value.pos)] })
+          else set = set.update({ filter: (from) => from !== e.value.pos })
+        }
+      }
+      if (state !== null) updateBreakpoints(state, set)
+      return set
+    },
+  })
+
+  const breakpointExtension = [
+    breakpointState,
+    gutter({
+      class: 'cm-breakpoint-gutter',
+      markers: (v) => v.state.field(breakpointState),
+      initialSpacer: () => breakpointMarker,
+      domEventHandlers: {
+        mousedown(view, line) {
+          toggleBreakpoint(view, line.from)
+          return true
+        },
+      },
+      renderEmptyElements: true,
+    }),
+    EditorView.baseTheme({
+      '.cm-breakpoint-gutter .cm-gutterElement': {
+        position: 'relative',
+        paddingLeft: '4px',
+        paddingRight: '4px',
+        paddingTop: '2px',
+        cursor: 'pointer',
+        background: 'inherit',
+        fontSize: '0.7em',
+      },
+      '.cm-breakpoint-gutter .cm-gutterElement:hover': {
+        opacity: '40%',
+      },
+      '.cm-breakpoint-gutter .cm-gutterElement:hover:after': {
+        position: 'absolute',
+        left: '4px',
+        top: '2px',
+        content: '"🔴"',
+      },
+    }),
+  ]
+
+  function toggleBreakpoint(view: EditorView, pos: number) {
+    state = view.state
+    const breakpoints = view.state.field(breakpointState)
+    let hasBreakpoint = false
+    breakpoints.between(pos, pos, () => {
+      hasBreakpoint = true
+    })
+    view.dispatch({
+      effects: breakpointEffect.of({ pos, on: !hasBreakpoint }),
+    })
+  }
+
+  return breakpointExtension
+}
+
+export { createBreakpointsExtension }

--- a/frontend/src/stores/executionStore.ts
+++ b/frontend/src/stores/executionStore.ts
@@ -106,11 +106,16 @@ function processInstructions(
       global_variable_changes: {},
       local_variable_changes: {},
     }
-    for (let j = rangeStart; j <= i; j++)
-      Object.assign(instruction, {
-        global_variable_changes: rawInstructions[j].global_variable_changes,
-        local_variable_changes: rawInstructions[j].local_variable_changes,
-      })
+    for (let j = rangeStart; j <= i; j++) {
+      Object.assign(
+        instruction.global_variable_changes,
+        rawInstructions[j].global_variable_changes,
+      )
+      Object.assign(
+        instruction.local_variable_changes,
+        rawInstructions[j].local_variable_changes,
+      )
+    }
     rangeStart = i + 1
     newInstructions.push(instruction)
   }

--- a/frontend/src/stores/executionStore.ts
+++ b/frontend/src/stores/executionStore.ts
@@ -10,10 +10,13 @@ interface dataVal {
 interface ExecutionState {
   currentStep: number
   setStep: (step: number) => void
+  rawInstructions: instruction[]
   instructions: instruction[]
   setInstructions: (instructions: instruction[]) => void
   data: dataVal[]
   allVariableNames: string[]
+  selectedLineNumbers: number[]
+  updateSelectedLineNumbers: (lineNumbers: number[]) => void
 }
 
 export const useExecutionStore = create<ExecutionState>((set, get) => ({
@@ -37,6 +40,7 @@ export const useExecutionStore = create<ExecutionState>((set, get) => ({
     }
     set({ currentStep: step, data: newData })
   },
+  rawInstructions: [],
   instructions: [],
   setInstructions: (instructions: instruction[]) => {
     const allVariableNames = new Set<string>()
@@ -52,11 +56,63 @@ export const useExecutionStore = create<ExecutionState>((set, get) => ({
     }
     set({
       currentStep: 0,
-      instructions,
+      rawInstructions: instructions,
+      instructions: processInstructions(
+        instructions,
+        get().selectedLineNumbers,
+      ),
       data: [],
       allVariableNames: [...allVariableNames],
     })
   },
   data: [],
   allVariableNames: [],
+  selectedLineNumbers: [],
+  updateSelectedLineNumbers: (lineNumbers: number[]) => {
+    let unchanged = true
+    if (lineNumbers.length !== get().selectedLineNumbers.length)
+      unchanged = false
+    else {
+      for (let i = 0; i < lineNumbers.length; i++) {
+        if (lineNumbers[i] !== get().selectedLineNumbers[i]) unchanged = false
+      }
+    }
+    if (unchanged) return
+    set({
+      selectedLineNumbers: lineNumbers,
+      instructions: processInstructions(get().rawInstructions, lineNumbers),
+      data: [],
+      currentStep: 0,
+    })
+  },
 }))
+
+function processInstructions(
+  rawInstructions: instruction[],
+  lineNumbers: number[],
+): instruction[] {
+  const newInstructions: instruction[] = []
+  const lineNumberSet = new Set(lineNumbers)
+  let rangeStart = 0
+  for (let i = 0; i < rawInstructions.length; i++) {
+    if (
+      lineNumberSet.size > 0 &&
+      !lineNumberSet.has(rawInstructions[i].line_number)
+    )
+      continue
+    const instruction = {
+      line_number: rawInstructions[i].line_number,
+      function_scope: rawInstructions[i].function_scope,
+      global_variable_changes: {},
+      local_variable_changes: {},
+    }
+    for (let j = rangeStart; j <= i; j++)
+      Object.assign(instruction, {
+        global_variable_changes: rawInstructions[j].global_variable_changes,
+        local_variable_changes: rawInstructions[j].local_variable_changes,
+      })
+    rangeStart = i + 1
+    newInstructions.push(instruction)
+  }
+  return newInstructions
+}


### PR DESCRIPTION
This PR implements breakpoints, allowing users to filter the lines shown during code execution. The style of the breakpoints are similar to VS Code's breakpoints, and can be toggled while editing/running the code. When no breakpoints are selected, it defaults to including every single line.

Can be tested in this [deployment](https://feat-filter-steps.d1fr5et3wgts3j.amplifyapp.com/).

![Screenshot 2023-07-13 at 4 14 58 PM](https://github.com/huajun07/codesketcher/assets/30954848/aaa04d88-58bd-42f2-8c13-090bae1309cb)
