### PR TITLE
feat: consolidated visual area

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -29,9 +29,11 @@
         "react-cytoscapejs": "^2.0.0",
         "react-data-grid": "^7.0.0-beta.30",
         "react-dom": "^18.2.0",
-        "react-icons": "^4.8.0",
+        "react-icons": "^4.10.1",
+        "react-moveable": "^0.54.1",
         "react-router-dom": "^6.11.2",
         "react-scripts": "^5.0.1",
+        "react-selecto": "^1.26.0",
         "util": "^0.12.5",
         "uuid": "^9.0.0",
         "zustand": "^4.3.8"
@@ -1909,6 +1911,14 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw=="
     },
+    "node_modules/@cfcs/core": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@cfcs/core/-/core-0.0.6.tgz",
+      "integrity": "sha512-FxfJMwoLB8MEMConeXUCqtMGqxdtePQxRBOiGip9ULcYYam3WfCgoY6xdnMaSkYvRvmosp5iuG+TiPofm65+Pw==",
+      "dependencies": {
+        "@egjs/component": "^3.0.2"
+      }
+    },
     "node_modules/@chakra-ui/accordion": {
       "version": "2.1.11",
       "resolved": "https://registry.npmjs.org/@chakra-ui/accordion/-/accordion-2.1.11.tgz",
@@ -3472,6 +3482,34 @@
         "postcss-selector-parser": "^6.0.10"
       }
     },
+    "node_modules/@daybrush/utils": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@daybrush/utils/-/utils-1.13.0.tgz",
+      "integrity": "sha512-ALK12C6SQNNHw1enXK+UO8bdyQ+jaWNQ1Af7Z3FNxeAwjYhQT7do+TRE4RASAJ3ObaS2+TJ7TXR3oz2Gzbw0PQ=="
+    },
+    "node_modules/@egjs/agent": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/@egjs/agent/-/agent-2.4.3.tgz",
+      "integrity": "sha512-XvksSENe8wPeFlEVouvrOhKdx8HMniJ3by7sro2uPF3M6QqWwjzVcmvwoPtdjiX8O1lfRoLhQMp1a7NGlVTdIA=="
+    },
+    "node_modules/@egjs/children-differ": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@egjs/children-differ/-/children-differ-1.0.1.tgz",
+      "integrity": "sha512-DRvyqMf+CPCOzAopQKHtW+X8iN6Hy6SFol+/7zCUiE5y4P/OB8JP8FtU4NxtZwtafvSL4faD5KoQYPj3JHzPFQ==",
+      "dependencies": {
+        "@egjs/list-differ": "^1.0.0"
+      }
+    },
+    "node_modules/@egjs/component": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@egjs/component/-/component-3.0.4.tgz",
+      "integrity": "sha512-sXA7bGbIeLF2OAw/vpka66c6QBBUPcA4UUhR4WGJfnp2XWdiI8QrnJGJMr/UxpE/xnevX9tN3jvNPlW8WkHl3g=="
+    },
+    "node_modules/@egjs/list-differ": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@egjs/list-differ/-/list-differ-1.0.1.tgz",
+      "integrity": "sha512-OTFTDQcWS+1ZREOdCWuk5hCBgYO4OsD30lXcOCyVOAjXMhgL5rBRDnt/otb6Nz8CzU0L/igdcaQBDLWc4t9gvg=="
+    },
     "node_modules/@emotion/babel-plugin": {
       "version": "11.11.0",
       "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.11.0.tgz",
@@ -4696,6 +4734,31 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.3.0.tgz",
       "integrity": "sha512-IthPJsJR85GhOkp3Hvp8zFOPK5ynKn6STyHa/WZpioK7E1aYDiBzpqQPrngc14DszIUkIrdd3k9Iu0XSzlP/1w=="
+    },
+    "node_modules/@scena/dragscroll": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scena/dragscroll/-/dragscroll-1.4.0.tgz",
+      "integrity": "sha512-3O8daaZD9VXA9CP3dra6xcgt/qrm0mg0xJCwiX6druCteQ9FFsXffkF8PrqxY4Z4VJ58fFKEa0RlKqbsi/XnRA==",
+      "dependencies": {
+        "@daybrush/utils": "^1.6.0",
+        "@scena/event-emitter": "^1.0.2"
+      }
+    },
+    "node_modules/@scena/event-emitter": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@scena/event-emitter/-/event-emitter-1.0.5.tgz",
+      "integrity": "sha512-AzY4OTb0+7ynefmWFQ6hxDdk0CySAq/D4efljfhtRHCOP7MBF9zUfhKG3TJiroVjASqVgkRJFdenS8ArZo6Olg==",
+      "dependencies": {
+        "@daybrush/utils": "^1.1.1"
+      }
+    },
+    "node_modules/@scena/matrix": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@scena/matrix/-/matrix-1.1.1.tgz",
+      "integrity": "sha512-JVKBhN0tm2Srl+Yt+Ywqu0oLgLcdemDQlD1OxmN9jaCTwaFPZ7tY8n6dhVgMEaR9qcR7r+kAlMXnSfNyYdE+Vg==",
+      "dependencies": {
+        "@daybrush/utils": "^1.4.0"
+      }
     },
     "node_modules/@sinonjs/commons": {
       "version": "1.8.6",
@@ -7455,6 +7518,23 @@
       "resolved": "https://registry.npmjs.org/css-select-base-adapter/-/css-select-base-adapter-0.1.1.tgz",
       "integrity": "sha512-jQVeeRG70QI08vSTwf1jHxp74JoZsr2XSgETae8/xC8ovSnL2WF87GTLO86Sbwdt2lK4Umg4HnnwMO4YF3Ce7w=="
     },
+    "node_modules/css-styled": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/css-styled/-/css-styled-1.0.8.tgz",
+      "integrity": "sha512-tCpP7kLRI8dI95rCh3Syl7I+v7PP+2JYOzWkl0bUEoSbJM+u8ITbutjlQVf0NC2/g4ULROJPi16sfwDIO8/84g==",
+      "dependencies": {
+        "@daybrush/utils": "^1.13.0"
+      }
+    },
+    "node_modules/css-to-mat": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/css-to-mat/-/css-to-mat-1.1.1.tgz",
+      "integrity": "sha512-kvpxFYZb27jRd2vium35G7q5XZ2WJ9rWjDUMNT36M3Hc41qCrLXFM5iEKMGXcrPsKfXEN+8l/riB4QzwwwiEyQ==",
+      "dependencies": {
+        "@daybrush/utils": "^1.13.0",
+        "@scena/matrix": "^1.0.0"
+      }
+    },
     "node_modules/css-tree": {
       "version": "1.0.0-alpha.37",
       "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.37.tgz",
@@ -9652,6 +9732,11 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
       "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
+    "node_modules/framework-utils": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/framework-utils/-/framework-utils-1.1.0.tgz",
+      "integrity": "sha512-KAfqli5PwpFJ8o3psRNs8svpMGyCSAe8nmGcjQ0zZBWN2H6dZDnq+ABp3N3hdUmFeMrLtjOCTXD4yplUJIWceg=="
+    },
     "node_modules/fresh": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
@@ -9732,6 +9817,15 @@
       "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/gesto": {
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/gesto/-/gesto-1.19.1.tgz",
+      "integrity": "sha512-ofWVEdqmnpFm3AFf7aoclhoayseb3OkwSiXbXusKYu/99iN5HgeWP+SWqdghQ5TFlOgP5Zlz+6SY8mP2V0kFaQ==",
+      "dependencies": {
+        "@daybrush/utils": "^1.13.0",
+        "@scena/event-emitter": "^1.0.2"
       }
     },
     "node_modules/get-caller-file": {
@@ -13060,6 +13154,22 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/keycode": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/keycode/-/keycode-2.2.1.tgz",
+      "integrity": "sha512-Rdgz9Hl9Iv4QKi8b0OlCRQEzp4AgVxyCtz5S/+VIHezDmrDhkp2N2TqBWOLz0/gbeREXOOiI9/4b8BY9uw2vFg=="
+    },
+    "node_modules/keycon": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/keycon/-/keycon-1.4.0.tgz",
+      "integrity": "sha512-p1NAIxiRMH3jYfTeXRs2uWbVJ1WpEjpi8ktzUyBJsX7/wn2qu2VRXktneBLNtKNxJmlUYxRi9gOJt1DuthXR7A==",
+      "dependencies": {
+        "@cfcs/core": "^0.0.6",
+        "@daybrush/utils": "^1.7.1",
+        "@scena/event-emitter": "^1.0.2",
+        "keycode": "^2.2.0"
+      }
+    },
     "node_modules/kind-of": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
@@ -13839,6 +13949,14 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/overlap-area": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/overlap-area/-/overlap-area-1.1.0.tgz",
+      "integrity": "sha512-3dlJgJCaVeXH0/eZjYVJvQiLVVrPO4U1ZGqlATtx6QGO3b5eNM6+JgUKa7oStBTdYuGTk7gVoABCW6Tp+dhRdw==",
+      "dependencies": {
+        "@daybrush/utils": "^1.7.1"
       }
     },
     "node_modules/p-limit": {
@@ -15632,6 +15750,15 @@
         "react": "^15.3.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
       }
     },
+    "node_modules/react-css-styled": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/react-css-styled/-/react-css-styled-1.1.9.tgz",
+      "integrity": "sha512-M7fJZ3IWFaIHcZEkoFOnkjdiUFmwd8d+gTh2bpqMOcnxy/0Gsykw4dsL4QBiKsxcGow6tETUa4NAUcmJF+/nfw==",
+      "dependencies": {
+        "css-styled": "~1.0.8",
+        "framework-utils": "^1.1.0"
+      }
+    },
     "node_modules/react-cytoscapejs": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/react-cytoscapejs/-/react-cytoscapejs-2.0.0.tgz",
@@ -15807,9 +15934,9 @@
       }
     },
     "node_modules/react-icons": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.8.0.tgz",
-      "integrity": "sha512-N6+kOLcihDiAnj5Czu637waJqSnwlMNROzVZMhfX68V/9bu9qHaMIJC4UdozWoOk57gahFCNHwVvWzm0MTzRjg==",
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.10.1.tgz",
+      "integrity": "sha512-/ngzDP/77tlCfqthiiGNZeYFACw85fUjZtLbedmJ5DTlNDIwETxhwBzdOJ21zj4iJdvc0J3y7yOsX3PpxAJzrw==",
       "peerDependencies": {
         "react": "*"
       }
@@ -15818,6 +15945,26 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
+    "node_modules/react-moveable": {
+      "version": "0.54.1",
+      "resolved": "https://registry.npmjs.org/react-moveable/-/react-moveable-0.54.1.tgz",
+      "integrity": "sha512-Kj2ifw9nk3LZvu7ezhst8Z5WBPRr+yVv9oROwrBirFlHmwGHHZXUGk5Gaezu+JGqqNRsQJncVMW5Uf68KSSOvg==",
+      "dependencies": {
+        "@daybrush/utils": "^1.13.0",
+        "@egjs/agent": "^2.2.1",
+        "@egjs/children-differ": "^1.0.1",
+        "@egjs/list-differ": "^1.0.0",
+        "@scena/dragscroll": "^1.4.0",
+        "@scena/event-emitter": "^1.0.5",
+        "@scena/matrix": "^1.1.1",
+        "css-to-mat": "^1.1.1",
+        "framework-utils": "^1.1.0",
+        "gesto": "^1.19.0",
+        "overlap-area": "^1.1.0",
+        "react-css-styled": "^1.1.9",
+        "react-selecto": "^1.25.0"
+      }
     },
     "node_modules/react-nanny": {
       "version": "2.15.0",
@@ -15988,6 +16135,14 @@
       "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/react-selecto": {
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/react-selecto/-/react-selecto-1.26.0.tgz",
+      "integrity": "sha512-aBTZEYA68uE+o8TytNjTb2GpIn4oKEv0U4LIow3cspJQlF/PdAnBwkq9UuiKVuFluu5kfLQ7Keu3S2Tihlmw0g==",
+      "dependencies": {
+        "selecto": "~1.26.0"
       }
     },
     "node_modules/react-style-singleton": {
@@ -16551,6 +16706,23 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
       "integrity": "sha512-mEugaLK+YfkijB4fx0e6kImuJdCIt2LxCRcbEYPqRGCs4F2ogyfZU5IAZRdjCP8JPq2AtdNoC/Dux63d9Kiryg=="
+    },
+    "node_modules/selecto": {
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/selecto/-/selecto-1.26.0.tgz",
+      "integrity": "sha512-cEFKdv5rmkF6pf2OScQJllaNp4UJy/FvviB40ZaMSHrQCxC72X/Q6uhzW1tlb2RE+0danvUNJTs64cI9VXtUyg==",
+      "dependencies": {
+        "@daybrush/utils": "^1.13.0",
+        "@egjs/children-differ": "^1.0.1",
+        "@scena/dragscroll": "^1.4.0",
+        "@scena/event-emitter": "^1.0.5",
+        "css-styled": "^1.0.8",
+        "css-to-mat": "^1.1.1",
+        "framework-utils": "^1.1.0",
+        "gesto": "^1.19.1",
+        "keycon": "^1.2.0",
+        "overlap-area": "^1.1.0"
+      }
     },
     "node_modules/selfsigned": {
       "version": "2.1.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -34,9 +34,11 @@
     "react-cytoscapejs": "^2.0.0",
     "react-data-grid": "^7.0.0-beta.30",
     "react-dom": "^18.2.0",
-    "react-icons": "^4.8.0",
+    "react-icons": "^4.10.1",
+    "react-moveable": "^0.54.1",
     "react-router-dom": "^6.11.2",
     "react-scripts": "^5.0.1",
+    "react-selecto": "^1.26.0",
     "util": "^0.12.5",
     "uuid": "^9.0.0",
     "zustand": "^4.3.8"

--- a/frontend/src/components/Visual/GraphVisualization/Graph.tsx
+++ b/frontend/src/components/Visual/GraphVisualization/Graph.tsx
@@ -10,10 +10,12 @@ interface GraphProps {
   adjacencyList: number[][] | [number, number][][]
   displayData: { name: string; array: string[] }[]
   cyRef: React.MutableRefObject<cytoscape.Core | null>
+  locked: boolean
 }
 
 export const Graph = (props: GraphProps) => {
-  const { directed, weighted, adjacencyList, displayData, cyRef } = props
+  const { directed, weighted, adjacencyList, displayData, cyRef, locked } =
+    props
 
   const n = adjacencyList.length
   const elements: cytoscape.ElementDefinition[] = []
@@ -66,6 +68,9 @@ export const Graph = (props: GraphProps) => {
       elements={elements}
       layout={{ name: 'cola' }}
       style={{ height: '100%', width: '100%' }}
+      userPanningEnabled={!locked}
+      userZoomingEnabled={!locked}
+      boxSelectionEnabled={!locked}
       stylesheet={[
         {
           selector: 'edge',

--- a/frontend/src/components/Visual/GraphVisualization/Graph.tsx
+++ b/frontend/src/components/Visual/GraphVisualization/Graph.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react'
 import CytoscapeComponent from 'react-cytoscapejs'
 import cytoscape from 'cytoscape'
 import cola from 'cytoscape-cola'
@@ -16,6 +17,13 @@ interface GraphProps {
 export const Graph = (props: GraphProps) => {
   const { directed, weighted, adjacencyList, displayData, cyRef, locked } =
     props
+
+  useEffect(() => {
+    // block all pointer events on graph while locked
+    const container = cyRef.current?.container?.()
+    if (container === null || container === undefined) return
+    container.style.pointerEvents = locked ? 'none' : 'auto'
+  }, [cyRef, locked])
 
   const n = adjacencyList.length
   const elements: cytoscape.ElementDefinition[] = []
@@ -68,9 +76,6 @@ export const Graph = (props: GraphProps) => {
       elements={elements}
       layout={{ name: 'cola' }}
       style={{ height: '100%', width: '100%' }}
-      userPanningEnabled={!locked}
-      userZoomingEnabled={!locked}
-      boxSelectionEnabled={!locked}
       stylesheet={[
         {
           selector: 'edge',

--- a/frontend/src/components/Visual/GraphVisualization/index.tsx
+++ b/frontend/src/components/Visual/GraphVisualization/index.tsx
@@ -1,4 +1,5 @@
 import { useRef, useState } from 'react'
+import { FaArrowsAlt } from 'react-icons/fa'
 import { AddIcon, DeleteIcon, MinusIcon, SettingsIcon } from '@chakra-ui/icons'
 import { Box, Button, Center, Text, Tooltip } from '@chakra-ui/react'
 import cytoscape from 'cytoscape'
@@ -22,10 +23,11 @@ enum EdgeFormat {
 
 interface GraphVisualizationProps {
   erase: () => void
+  selected: boolean
 }
 
 export const GraphVisualization = (props: GraphVisualizationProps) => {
-  const { erase } = props
+  const { erase, selected } = props
 
   const [settings, setSettings] = useState<GraphSettings>({
     directed: false,
@@ -120,13 +122,20 @@ export const GraphVisualization = (props: GraphVisualizationProps) => {
   }
 
   return (
-    <Box w="full" position="relative">
+    <Box
+      w="full"
+      h="full"
+      position="relative"
+      border="1px solid black"
+      borderRadius={8}
+    >
       <Button
         onClick={() => setSettingsOpen(!settingsOpen)}
         mt={4}
         ml={4}
         position="absolute"
         zIndex={1}
+        opacity={0.8}
       >
         <SettingsIcon />
       </Button>
@@ -139,8 +148,21 @@ export const GraphVisualization = (props: GraphVisualizationProps) => {
         right="0"
         zIndex={1}
         colorScheme="red"
+        opacity={0.8}
       >
         <DeleteIcon />
+      </Button>
+
+      <Button
+        className="visual-component-move-button"
+        mb={4}
+        ml={4}
+        position="absolute"
+        bottom="0"
+        zIndex={1}
+        opacity={0.8}
+      >
+        <FaArrowsAlt />
       </Button>
 
       <Tooltip label="Zoom in">
@@ -156,6 +178,7 @@ export const GraphVisualization = (props: GraphVisualizationProps) => {
           borderBottom="1px"
           borderBottomColor="gray.300"
           zIndex={1}
+          opacity={0.8}
         >
           <AddIcon />
         </Button>
@@ -171,13 +194,14 @@ export const GraphVisualization = (props: GraphVisualizationProps) => {
           right="0"
           size="sm"
           zIndex={1}
+          opacity={0.8}
         >
           <MinusIcon />
         </Button>
       </Tooltip>
 
       {error && (
-        <Center h="full" w="full">
+        <Center h="full" w="full" px={8}>
           <Text>{error}</Text>
         </Center>
       )}
@@ -190,6 +214,7 @@ export const GraphVisualization = (props: GraphVisualizationProps) => {
           weighted={settings.weighted}
           displayData={displayData}
           cyRef={cyRef}
+          locked={selected}
         />
       )}
 

--- a/frontend/src/components/Visual/GraphVisualization/index.tsx
+++ b/frontend/src/components/Visual/GraphVisualization/index.tsx
@@ -122,13 +122,7 @@ export const GraphVisualization = (props: GraphVisualizationProps) => {
   }
 
   return (
-    <Box
-      w="full"
-      h="full"
-      position="relative"
-      border="1px solid black"
-      borderRadius={8}
-    >
+    <Box w="full" h="full" position="relative">
       <Button
         onClick={() => setSettingsOpen(!settingsOpen)}
         mt={4}
@@ -151,18 +145,6 @@ export const GraphVisualization = (props: GraphVisualizationProps) => {
         opacity={0.8}
       >
         <DeleteIcon />
-      </Button>
-
-      <Button
-        className="visual-component-move-button"
-        mb={4}
-        ml={4}
-        position="absolute"
-        bottom="0"
-        zIndex={1}
-        opacity={0.8}
-      >
-        <FaArrowsAlt />
       </Button>
 
       <Tooltip label="Zoom in">

--- a/frontend/src/components/Visual/GraphVisualization/index.tsx
+++ b/frontend/src/components/Visual/GraphVisualization/index.tsx
@@ -1,5 +1,4 @@
 import { useRef, useState } from 'react'
-import { FaArrowsAlt } from 'react-icons/fa'
 import { AddIcon, DeleteIcon, MinusIcon, SettingsIcon } from '@chakra-ui/icons'
 import { Box, Button, Center, Text, Tooltip } from '@chakra-ui/react'
 import cytoscape from 'cytoscape'

--- a/frontend/src/components/Visual/Moveable.css
+++ b/frontend/src/components/Visual/Moveable.css
@@ -1,0 +1,3 @@
+.moveable-control-box {
+  z-index: 10 !important;
+}

--- a/frontend/src/components/Visual/Moveable.css
+++ b/frontend/src/components/Visual/Moveable.css
@@ -1,3 +1,3 @@
 .moveable-control-box {
-  z-index: 10 !important;
+  z-index: 100 !important;
 }

--- a/frontend/src/components/Visual/VisualArea.module.css
+++ b/frontend/src/components/Visual/VisualArea.module.css
@@ -3,4 +3,13 @@
   z-index: 100;
   min-width: 400px;
   min-height: 300px;
+  cursor: all-scroll;
+}
+
+.visual-component > * {
+  cursor: auto;
+}
+
+.visual-component-selected > * {
+  cursor: all-scroll;
 }

--- a/frontend/src/components/Visual/VisualArea.module.css
+++ b/frontend/src/components/Visual/VisualArea.module.css
@@ -1,0 +1,4 @@
+.visual-component {
+  position: absolute;
+  z-index: 100;
+}

--- a/frontend/src/components/Visual/VisualArea.module.css
+++ b/frontend/src/components/Visual/VisualArea.module.css
@@ -1,4 +1,6 @@
 .visual-component {
   position: absolute;
   z-index: 100;
+  min-width: 400px;
+  min-height: 300px;
 }

--- a/frontend/src/components/Visual/VisualArea.tsx
+++ b/frontend/src/components/Visual/VisualArea.tsx
@@ -87,7 +87,7 @@ export const VisualArea = () => {
           />
           <Selecto
             dragContainer={'#visual-area-container'}
-            selectFromInside={true}
+            selectFromInside={false}
             selectByClick={true}
             selectableTargets={['.visual-component-move-button']}
             onDragStart={(event) => {

--- a/frontend/src/components/Visual/VisualArea.tsx
+++ b/frontend/src/components/Visual/VisualArea.tsx
@@ -1,79 +1,128 @@
-import { useState } from 'react'
-import { AddIcon, InfoIcon } from '@chakra-ui/icons'
-import {
-  Button,
-  Center,
-  Code,
-  Flex,
-  Tab,
-  TabList,
-  TabPanel,
-  TabPanels,
-  Tabs,
-  Tooltip,
-} from '@chakra-ui/react'
+import './Moveable.css'
+
+import { useRef, useState } from 'react'
+import { PiGraph } from 'react-icons/pi'
+import Moveable from 'react-moveable'
+import Selecto from 'react-selecto'
+import { InfoIcon } from '@chakra-ui/icons'
+import { Box, Button, Flex, Tooltip } from '@chakra-ui/react'
 import { v4 as uuidv4 } from 'uuid'
 
 import { FAQModal } from './FAQModal'
 import { GraphVisualization } from './GraphVisualization'
+import styles from './VisualArea.module.css'
 
 export const VisualArea = () => {
+  const moveableRef = useRef<Moveable>(null)
+  const [selectedTargets, setSelectedTargets] = useState<
+    (HTMLElement | SVGElement)[]
+  >([])
+
   const [faqOpen, setFAQOpen] = useState(false)
 
   const [childKeys, setChildKeys] = useState<string[]>([])
-  const [tabIndex, setTabIndex] = useState<number>(0)
 
   const eraseVisualization = (key: string) => {
     const index = childKeys.findIndex((x) => x === key)
     if (index === -1) return
-    if (tabIndex >= index) setTabIndex(tabIndex === 0 ? 0 : tabIndex - 1)
     setChildKeys(childKeys.filter((x) => x !== key))
+    setSelectedTargets(selectedTargets.filter((x) => x.dataset.key !== key))
   }
 
   const addVisualization = () => {
-    setTabIndex(childKeys.length)
     setChildKeys([...childKeys, uuidv4()])
   }
 
   return (
     <>
-      <Tabs w="full" index={tabIndex} onChange={(index) => setTabIndex(index)}>
-        <TabList>
+      <Flex direction="column" w="full">
+        <FAQModal open={faqOpen} toggle={() => setFAQOpen(!faqOpen)} />
+        <Flex>
           <Tooltip label="FAQ">
             <Button borderRadius={0} onClick={() => setFAQOpen(true)}>
               <InfoIcon />
             </Button>
           </Tooltip>
-
-          {childKeys.map((key, index) => (
-            <Tab key={key}>{index}</Tab>
-          ))}
-
-          <Tooltip label="Add visualization">
-            <Button borderRadius={0} onClick={addVisualization}>
-              <AddIcon />
+          <Tooltip label="Add a graph">
+            <Button borderRadius={0} onClick={() => addVisualization()}>
+              <PiGraph />
             </Button>
           </Tooltip>
-        </TabList>
+        </Flex>
 
-        {childKeys.length > 0 ? (
-          <TabPanels h="full">
-            {childKeys.map((key) => (
-              <TabPanel p={0} key={key}>
-                <Flex h="calc(100vh - 189px)" alignItems="stretch">
-                  <GraphVisualization erase={() => eraseVisualization(key)} />
-                </Flex>
-              </TabPanel>
-            ))}
-          </TabPanels>
-        ) : (
-          <Center h="full" w="full">
-            Click the&nbsp; <Code>+</Code>&nbsp; button above to add a
-            visualization and get started!
-          </Center>
-        )}
-      </Tabs>
-      <FAQModal open={faqOpen} toggle={() => setFAQOpen(!faqOpen)} />
+        <Box
+          flexGrow={1}
+          position="relative"
+          overflow="hidden"
+          id="visual-area-container"
+        >
+          {childKeys.map((key) => (
+            <div
+              key={key}
+              className={'visual-component ' + styles['visual-component']}
+              style={{ height: 300, width: 400, backgroundColor: 'white' }}
+              data-key={key}
+            >
+              <GraphVisualization
+                erase={() => eraseVisualization(key)}
+                selected={selectedTargets.some((x) => x.dataset.key === key)}
+              />
+            </div>
+          ))}
+          <Moveable
+            ref={moveableRef}
+            target={selectedTargets}
+            individualGroupable
+            draggable
+            onDrag={({ target, transform }) => {
+              target.style.transform = transform
+            }}
+            resizable
+            onResize={({ target, width, height, delta }) => {
+              width = Math.max(width, 400) // at least 400px wide
+              height = Math.max(height, 300) // at least 300px tall
+              delta[0] && (target.style.width = `${width}px`)
+              delta[1] && (target.style.height = `${height}px`)
+            }}
+          />
+          <Selecto
+            dragContainer={'#visual-area-container'}
+            selectFromInside={true}
+            selectByClick={true}
+            selectableTargets={['.visual-component-move-button']}
+            onDragStart={(event) => {
+              event.preventDrag()
+              const moveable = moveableRef.current
+              if (moveable === null) return
+              const target = event.inputEvent.target
+              if (
+                moveable.isMoveableElement(target) ||
+                selectedTargets.some((t) => t === target || t.contains(target))
+              ) {
+                event.stop()
+              }
+            }}
+            onSelectEnd={(event) => {
+              const moveable = moveableRef.current
+              if (moveable === null) return
+              if (event.isDragStartEnd) {
+                event.inputEvent.preventDefault()
+                moveable.waitToChangeTarget().then(() => {
+                  moveable.dragStart(event.inputEvent)
+                })
+              }
+              setSelectedTargets(
+                event.selected.map((x) => {
+                  let root = x
+                  while (root.dataset.key === undefined)
+                    root = root.parentElement as HTMLElement
+                  return root
+                }),
+              )
+            }}
+          />
+        </Box>
+      </Flex>
     </>
   )
 }

--- a/frontend/src/components/Visual/VisualArea.tsx
+++ b/frontend/src/components/Visual/VisualArea.tsx
@@ -55,6 +55,7 @@ export const VisualArea = () => {
           position="relative"
           overflow="hidden"
           id="visual-area-container"
+          bgColor="gray.50"
         >
           {childKeys.map((key) => (
             <div

--- a/frontend/src/components/Visual/VisualArea.tsx
+++ b/frontend/src/components/Visual/VisualArea.tsx
@@ -78,9 +78,8 @@ export const VisualArea = () => {
               target.style.transform = transform
             }}
             resizable
-            onResize={({ target, width, height, delta }) => {
-              width = Math.max(width, 400) // at least 400px wide
-              height = Math.max(height, 300) // at least 300px tall
+            onResize={({ target, width, height, delta, drag }) => {
+              target.style.transform = drag.transform
               delta[0] && (target.style.width = `${width}px`)
               delta[1] && (target.style.height = `${height}px`)
             }}


### PR DESCRIPTION
This PR removes the tabbing used to display multiple graph visualizations, and consolidates it into a single visual area instead.

Each graph visualization can be dragged/resized by clicking on the "move" button in the lower left corner. Movement of the graph is locked while drag/resizing is enabled, to prevent unwanted shifts to the graph while users shift the whole element.

Future PRs will add other types of visualization, within the same area, such as for displaying arrays / objects. FAQ is still outdated (and will remain so) until everything is finalized for next release.

Test it out [here](https://feat-visual-area.d1fr5et3wgts3j.amplifyapp.com/)

![Screenshot 2023-07-19 at 6 10 45 PM](https://github.com/huajun07/codesketcher/assets/30954848/9fe9998c-7273-4b03-844b-9b57888e3e95)
