### PR TITLE
Chore/upgrade chakra autocomplete

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v1
       - name: Install dependencies
         # 👇 Install dependencies with the same package manager used in the project (replace it as needed), e.g. yarn, npm, pnpm
-        run: npm ci --force
+        run: npm ci
         # 👇 Adds Chromatic as a step in the workflow
       - name: Publish to Chromatic
         uses: chromaui/action@v1

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -30,4 +30,5 @@ jobs:
           # 👇 Runs Chromatic CLI in ./frontend
           workingDir: frontend
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          autoAcceptChanges: true # 👈 Option to accept all changes
           skip: ${{ github.event.pull_request.draft == true }}

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -2,7 +2,7 @@ FROM node:18-alpine AS builder
 
 WORKDIR /usr/src/app
 COPY package*.json ./
-RUN npm ci --force
+RUN npm ci
 COPY . .
 EXPOSE 3000
 CMD ["npm", "run", "local"]

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,7 +11,7 @@
         "@chakra-ui/react": "^2.6.1",
         "@chakra-ui/theme": "^3.1.1",
         "@chakra-ui/theme-tools": "^2.0.17",
-        "@choc-ui/chakra-autocomplete": "5.1.5",
+        "@choc-ui/chakra-autocomplete": "^5.1.7",
         "@codemirror/lang-python": "^6.1.2",
         "@emotion/react": "^11.11.0",
         "@emotion/styled": "^11.11.0",
@@ -3497,9 +3497,9 @@
       }
     },
     "node_modules/@choc-ui/chakra-autocomplete": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@choc-ui/chakra-autocomplete/-/chakra-autocomplete-5.1.5.tgz",
-      "integrity": "sha512-9WxM+rcp6Qo3vvRDh3ObMp1gSWAqaoj3yNda2jzkjTcpfV8IyJ4wZLRkO4kaVm5RNfz5AkOCqVEnWRGq5OT7ig==",
+      "version": "5.1.7",
+      "resolved": "https://registry.npmjs.org/@choc-ui/chakra-autocomplete/-/chakra-autocomplete-5.1.7.tgz",
+      "integrity": "sha512-M6TJYBGBFA0RjCOlECtm6JxzLLdk446o0ZJw4lnK9ZoxRfV4jnIHSK0yjnTM810fJ2NrDpK+S6hDbMdx7s1mUA==",
       "dependencies": {
         "@chakra-ui/layout": "^2.1.5",
         "@chakra-ui/react-utils": "^2.0.5",
@@ -3511,10 +3511,10 @@
         "node": ">=10"
       },
       "peerDependencies": {
-        "@chakra-ui/react": "^2.2.8",
+        "@chakra-ui/react": "^2.5.5",
         "@emotion/react": "^11.10.0",
         "@emotion/styled": "^11.10.0",
-        "framer-motion": "^6 || 7",
+        "framer-motion": ">7.6.14",
         "react": "^18.2.0"
       }
     },
@@ -28605,9 +28605,9 @@
       "requires": {}
     },
     "@choc-ui/chakra-autocomplete": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@choc-ui/chakra-autocomplete/-/chakra-autocomplete-5.1.5.tgz",
-      "integrity": "sha512-9WxM+rcp6Qo3vvRDh3ObMp1gSWAqaoj3yNda2jzkjTcpfV8IyJ4wZLRkO4kaVm5RNfz5AkOCqVEnWRGq5OT7ig==",
+      "version": "5.1.7",
+      "resolved": "https://registry.npmjs.org/@choc-ui/chakra-autocomplete/-/chakra-autocomplete-5.1.7.tgz",
+      "integrity": "sha512-M6TJYBGBFA0RjCOlECtm6JxzLLdk446o0ZJw4lnK9ZoxRfV4jnIHSK0yjnTM810fJ2NrDpK+S6hDbMdx7s1mUA==",
       "requires": {
         "@chakra-ui/layout": "^2.1.5",
         "@chakra-ui/react-utils": "^2.0.5",
@@ -41844,9 +41844,9 @@
       }
     },
     "react-data-grid": {
-      "version": "7.0.0-beta.30",
-      "resolved": "https://registry.npmjs.org/react-data-grid/-/react-data-grid-7.0.0-beta.30.tgz",
-      "integrity": "sha512-QdNXxl+fSGTy+S6TD7O9h1slSX7X+0dTy8Z3n1zWvhlfNoNdWmS5VsUbbv2xHyVywBvyUVuSOFIueKnuQ4IeSw==",
+      "version": "7.0.0-beta.34",
+      "resolved": "https://registry.npmjs.org/react-data-grid/-/react-data-grid-7.0.0-beta.34.tgz",
+      "integrity": "sha512-OwOP77vabb47xhbvHCXJ2QwFHsfduoLJhgXncGe0gIjrrwJ9xr2SdfEe/U6KAfHnLuBDxCDoY0SOgfJiOQtd+Q==",
       "requires": {
         "clsx": "^1.1.1"
       }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,7 +20,7 @@
     "@chakra-ui/react": "^2.6.1",
     "@chakra-ui/theme": "^3.1.1",
     "@chakra-ui/theme-tools": "^2.0.17",
-    "@choc-ui/chakra-autocomplete": "5.1.5",
+    "@choc-ui/chakra-autocomplete": "^5.1.7",
     "@codemirror/lang-python": "^6.1.2",
     "@emotion/react": "^11.11.0",
     "@emotion/styled": "^11.11.0",

--- a/scripts/up.sh
+++ b/scripts/up.sh
@@ -6,7 +6,7 @@ cd backend
 [ -d "build" ] || npm run build
 
 cd ../frontend
-[ -d "node_modules" ] || npm ci --force
+[ -d "node_modules" ] || npm ci
 
 cd ../
 export GOOGLE_CLIENT_ID=$(aws ssm get-parameter --name /codesketcher-dev/google/client-id --output text --query "Parameter.Value")


### PR DESCRIPTION
This PR upgrades the `@choc-ui/chakra-autocomplete` dependency from ^5.1.5 to ^5.1.7, which resolves a version conflict. We no longer need to do `npm install --force` or `npm ci --force` to install modules.