### PR TITLE
Chore/editor locked mode

### DIFF
--- a/frontend/src/components/CodeIDE/CodeIDE.tsx
+++ b/frontend/src/components/CodeIDE/CodeIDE.tsx
@@ -58,6 +58,7 @@ export const CodeIDE = (props: codeIDEProps) => {
     <CodeMirror
       value={code}
       height="calc(100vh - 125px)"
+      style={props.editable ? {} : { cursor: 'not-allowed' }}
       editable={props.editable}
       readOnly={!props.editable}
       placeholder={placeholder}

--- a/frontend/src/components/IO/TextIDE.tsx
+++ b/frontend/src/components/IO/TextIDE.tsx
@@ -14,7 +14,10 @@ export const TextIDE = (props: textIDEProps) => {
     <CodeMirror
       value={props.text}
       height="100%"
-      style={{ height: '100%' }}
+      style={{
+        height: '100%',
+        ...(!props.editable && { cursor: 'not-allowed' }),
+      }}
       editable={props.editable}
       readOnly={!props.editable}
       placeholder={props.placeholder}

--- a/frontend/src/components/IO/index.tsx
+++ b/frontend/src/components/IO/index.tsx
@@ -15,6 +15,7 @@ import { TextIDE } from './TextIDE'
 interface IOProps {
   output?: string | null
   index: number
+  editing: boolean
   setIndex: (newIndex: number) => void
 }
 
@@ -67,7 +68,7 @@ export const IO = (props: IOProps) => {
                   placeholder="Enter your input here (if any) "
                   text={input}
                   setText={setInput}
-                  editable={true}
+                  editable={props.editing}
                 />
               </Box>
             </TabPanel>

--- a/frontend/src/pages/Main/Main.tsx
+++ b/frontend/src/pages/Main/Main.tsx
@@ -183,7 +183,12 @@ export const Main = () => {
         <Flex position="relative" flex={1}>
           <Flex w="500px" borderRightWidth="1px" flexDirection="column">
             <DataTable />
-            <IO output={output} index={ioIndex} setIndex={setIOIndex} />
+            <IO
+              output={output}
+              index={ioIndex}
+              setIndex={setIOIndex}
+              editing={editing}
+            />
           </Flex>
           <Flex flex={1} flexDirection="column" minW="500px">
             <Flex flex={1}>

--- a/frontend/src/stories/IO.stories.tsx
+++ b/frontend/src/stories/IO.stories.tsx
@@ -13,7 +13,11 @@ const meta = {
     layout: 'centered',
   },
   // More on argTypes: https://storybook.js.org/docs/react/api/argtypes
-  argTypes: { output: { control: 'string' }, index: { control: 'number' } },
+  argTypes: {
+    output: { control: 'string' },
+    index: { control: 'number' },
+    editing: { control: 'boolean' },
+  },
   decorators: [
     (Story) => (
       <div style={{ minWidth: '500px', minHeight: '500px' }}>
@@ -32,6 +36,7 @@ export const Input: Story = {
   args: {
     output: '',
     index: 0,
+    editing: true,
   },
   parameters: {
     moduleMock: {
@@ -52,6 +57,7 @@ export const ChangedInput: Story = {
   args: {
     output: '',
     index: 0,
+    editing: true,
   },
   parameters: {
     moduleMock: {
@@ -74,5 +80,6 @@ export const Output: Story = {
   args: {
     output: 'Test Output',
     index: 1,
+    editing: true,
   },
 }

--- a/frontend/src/stories/IO.stories.tsx
+++ b/frontend/src/stories/IO.stories.tsx
@@ -76,6 +76,27 @@ export const ChangedInput: Story = {
   },
 }
 
+export const DisabledInput: Story = {
+  args: {
+    output: '',
+    index: 0,
+    editing: false,
+  },
+  parameters: {
+    moduleMock: {
+      mock: () => {
+        const mock = createMock(stores, 'useUserDataStore')
+        mock.mockImplementation(
+          stores.createUserStore({
+            input: 'Hello World',
+          }),
+        )
+        return [mock]
+      },
+    },
+  },
+}
+
 export const Output: Story = {
   args: {
     output: 'Test Output',


### PR DESCRIPTION
This PR implements #41. Input is no longer editable while code is executing. Cursor is changed to not-allowed when hovering over the Code IDE and input, if they are locked. Test it out [here](https://chore-editor-locked-mode.d1fr5et3wgts3j.amplifyapp.com/)