### PR TITLE
chore: style the toolbar to look nicer

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -30,5 +30,4 @@ jobs:
           # 👇 Runs Chromatic CLI in ./frontend
           workingDir: frontend
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
-          autoAcceptChanges: true # 👈 Option to accept all changes
           skip: ${{ github.event.pull_request.draft == true }}

--- a/frontend/src/components/Visual/VisualArea.tsx
+++ b/frontend/src/components/Visual/VisualArea.tsx
@@ -67,9 +67,14 @@ export const VisualArea = () => {
     <>
       <Flex direction="column" w="full">
         <FAQModal open={faqOpen} toggle={() => setFAQOpen(!faqOpen)} />
-        <Flex>
+        <Flex bgColor="gray.100">
           <Tooltip label="FAQ">
-            <Button borderRadius={0} onClick={() => setFAQOpen(true)}>
+            <Button
+              borderRadius={0}
+              onClick={() => setFAQOpen(true)}
+              borderRight="1px solid"
+              borderRightColor="gray.300"
+            >
               <InfoIcon />
             </Button>
           </Tooltip>
@@ -77,6 +82,8 @@ export const VisualArea = () => {
             <Button
               borderRadius={0}
               onClick={() => addVisualization(VisualizationType.Graph)}
+              borderRight="1px solid"
+              borderRightColor="gray.300"
             >
               <PiGraph />
             </Button>
@@ -85,6 +92,8 @@ export const VisualArea = () => {
             <Button
               borderRadius={0}
               onClick={() => addVisualization(VisualizationType.Array)}
+              borderRight="1px solid"
+              borderRightColor="gray.300"
             >
               <MdDataArray />
             </Button>


### PR DESCRIPTION
This PR styles the toolbar in the visual area to look more like a toolbar, by extending the background color to the full width, and adding lines between buttons. Test it out [here](https://chore-visual-area-toolbar.d1fr5et3wgts3j.amplifyapp.com/)

![Screenshot 2023-07-22 at 12 59 52 PM](https://github.com/huajun07/codesketcher/assets/30954848/72dccb23-85a4-4d5a-ba75-cd2e0f23b90b)
