### PR TITLE
fix: io area should extend to bottom of app

### DIFF
--- a/frontend/src/components/IO/index.tsx
+++ b/frontend/src/components/IO/index.tsx
@@ -83,3 +83,5 @@ export const IO = (props: IOProps) => {
     </>
   )
 }
+
+//test

--- a/frontend/src/components/IO/index.tsx
+++ b/frontend/src/components/IO/index.tsx
@@ -61,7 +61,7 @@ export const IO = (props: IOProps) => {
             bg="gray.200"
             borderRadius="1px"
           />
-          <TabPanels overflowY="scroll" height="100%" maxH="390px">
+          <TabPanels overflowY="scroll" height="100%" maxH="calc(60vh - 148px)">
             <TabPanel padding={0} height="100%">
               <Box height="100%">
                 <TextIDE


### PR DESCRIPTION
This PR fixes the IO area to extend to the bottom of the app, by setting a correct value of max height. Test it [here](https://fix-io-area.d1fr5et3wgts3j.amplifyapp.com/).

## Old

![Screenshot 2023-07-22 at 8 18 16 PM](https://github.com/huajun07/codesketcher/assets/30954848/fc403f7d-5ced-4a53-afb6-2551a409eb3b)


## New

![Screenshot 2023-07-22 at 8 17 53 PM](https://github.com/huajun07/codesketcher/assets/30954848/3eddc1b7-4c49-4cde-a27d-22cf61c16522)
