### PR TITLE
fix: io area should extend to bottom of app

### DIFF
--- a/frontend/src/components/IO/index.tsx
+++ b/frontend/src/components/IO/index.tsx
@@ -61,7 +61,7 @@ export const IO = (props: IOProps) => {
             bg="gray.200"
             borderRadius="1px"
           />
-          <TabPanels overflowY="scroll" height="100%" maxH="390px">
+          <TabPanels overflowY="scroll" height="100%" maxH="calc(60vh - 148px)">
             <TabPanel padding={0} height="100%">
               <Box height="100%">
                 <TextIDE


### PR DESCRIPTION
This PR fixes the IO area to extend to the bottom of the app, by setting a correct value of max height. Test it [here](https://fix-io-area.d1fr5et3wgts3j.amplifyapp.com/).