### PR TITLE
fix: add key to visual components

### DIFF
--- a/frontend/src/components/Visual/VisualArea.tsx
+++ b/frontend/src/components/Visual/VisualArea.tsx
@@ -130,6 +130,7 @@ export const VisualArea = () => {
                 padding={1}
                 borderColor="black.100"
                 borderRadius={8}
+                key={key}
                 data-key={key}
               >
                 {type === VisualizationType.Graph ? (


### PR DESCRIPTION
This PR fixes #99. The visual components were not assigned any keys, which caused them to render in other positions when one is deleted. Fixed by adding a key to them. Test it out (here)[https://fix-visual-component-deletion.d1fr5et3wgts3j.amplifyapp.com/]