### PR TITLE
fix: CPython generated variables are filtered out

### DIFF
--- a/services/executor/executor/main.py
+++ b/services/executor/executor/main.py
@@ -114,18 +114,20 @@ class Debugger(bdb.Bdb):
         self.current_raw_global_variables.pop("__builtins__", None)
         self.current_raw_local_variables.pop("__builtins__", None)
 
-        def filter_variable(x):
-            if inspect.ismodule(x):
+        def filter_variable(name, value):
+            if inspect.ismodule(value):
                 return True
-            if "importlib" in type(x).__module__:
+            if "importlib" in type(value).__module__:
+                return True
+            if name.startswith("."):  # filter out CPython generated variables
                 return True
             return False
 
         for name in list(self.current_raw_global_variables.keys()):
-            if filter_variable(self.current_raw_global_variables[name]):
+            if filter_variable(name, self.current_raw_global_variables[name]):
                 self.current_raw_global_variables.pop(name, None)
         for name in list(self.current_raw_local_variables.keys()):
-            if filter_variable(self.current_raw_local_variables[name]):
+            if filter_variable(name, self.current_raw_local_variables[name]):
                 self.current_raw_local_variables.pop(name, None)
 
         local_variables = self.clone_variables(self.current_raw_local_variables)

--- a/services/executor/tests/test_main.py
+++ b/services/executor/tests/test_main.py
@@ -764,14 +764,7 @@ def test_list_comprehension():
         "data": [
             {
                 "line_number": 1,
-                "local_variable_changes": {
-                    ".0": {
-                        "type": "range_iterator",
-                        "value": MatchesRegex(
-                            "<range\\_iterator object at 0x[0-9a-f]+>"
-                        ),
-                    }
-                },
+                "local_variable_changes": {},
                 "global_variable_changes": {},
                 "function_scope": [],
             },


### PR DESCRIPTION
This PR filters out variables generated by CPython, such as during list comprehension.

```
a = [_ for _ in range(1)]
```

The above code used to cause the executor to return a `.0` range iterator variable, but now it no longer does so.